### PR TITLE
Only query for what we do not have

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	arbor "github.com/arborchat/arbor-go"
+	"github.com/arborchat/muscadine/archive"
 	"github.com/jordwest/mock-conn"
 )
 
@@ -14,8 +15,9 @@ const testMsg = "{\"Type\":2,\"UUID\":\"92d24e9d-12cc-4742-6aaf-ea781a6b09ec\",\
 // reads data from the provided io.ReadWriter.
 func TestClient(t *testing.T) {
 	conn := mock_conn.NewConn()
+	arch := archive.New()
 	defer conn.Close()
-	c, err := Connect(conn.Client)
+	c, err := Connect(conn.Client, arch)
 	if err != nil {
 		t.Error("Connect errored with a valid io.ReadWriter", err)
 	}

--- a/tui/interfaces.go
+++ b/tui/interfaces.go
@@ -6,6 +6,12 @@ import (
 	arbor "github.com/arborchat/arbor-go"
 )
 
+// Client manages the connection between a TUI and a specific server
+type Client interface {
+	Composer
+	Archive
+}
+
 // Composer writes and sends protocol messages
 type Composer interface {
 	Reply(string, string) error

--- a/tui/tui.go
+++ b/tui/tui.go
@@ -27,13 +27,13 @@ type TUI struct {
 
 // NewTUI creates a new terminal user interface. The provided channel will be
 // used to relay any protocol messages initiated by the TUI.
-func NewTUI(composer Composer, archive Archive) (*TUI, error) {
+func NewTUI(client Client) (*TUI, error) {
 	gui, err := gocui.NewGui(gocui.OutputNormal)
 	if err != nil {
 		return nil, err
 	}
 	gui.InputEsc = true
-	hs, err := NewHistoryState(archive)
+	hs, err := NewHistoryState(client)
 	if err != nil {
 		return nil, err
 	}
@@ -42,7 +42,7 @@ func NewTUI(composer Composer, archive Archive) (*TUI, error) {
 		Gui:       gui,
 		messages:  make(chan *arbor.ChatMessage),
 		histState: hs,
-		Composer:  composer,
+		Composer:  client,
 	}
 	t.done = t.mainLoop()
 


### PR DESCRIPTION
This change was intended to simply prevent the client from asking for
messages that were already available in the history, but the process
of trying to do that led me to realize some deeper structural flaws
within the code.

I've unified the concept of the "Client" as being a type that provides
services that can compose messages and can look up messages in an archive.
Now you don't pass around instances of a client/composer/archive separately,
but rather you pass around a client that embeds those services. I hope that
this will improve clarity in the code, as a Client contains all services
relevant to a single server connection. If and when we ever add multi-server
features, it will hopefully be as simple as having the TUI juggle multiple
client intances.