### PR TITLE
Ensure cursor navigation stays on screen

### DIFF
--- a/tui/tui.go
+++ b/tui/tui.go
@@ -112,6 +112,13 @@ func quit(c *gocui.Gui, v *gocui.View) error {
 func (t *TUI) cursorDown(c *gocui.Gui, v *gocui.View) error {
 	t.histState.CursorDown()
 	t.reRender()
+	_, cursorEnd := t.histState.CursorLines()
+	_, currentY := v.Origin()
+	_, viewHeight := v.Size()
+	for currentY+viewHeight-1 <= cursorEnd {
+		t.scrollDown(c, v)
+		_, currentY = v.Origin()
+	}
 	return nil
 }
 
@@ -120,6 +127,12 @@ func (t *TUI) cursorDown(c *gocui.Gui, v *gocui.View) error {
 func (t *TUI) cursorUp(c *gocui.Gui, v *gocui.View) error {
 	t.histState.CursorUp()
 	t.reRender()
+	cursorStart, _ := t.histState.CursorLines()
+	_, currentY := v.Origin()
+	for currentY > 0 && currentY+1 > cursorStart {
+		t.scrollUp(c, v)
+		_, currentY = v.Origin()
+	}
 	return nil
 }
 


### PR DESCRIPTION
Previously, moving the cursor was completely independent of moving the
viewport. This created some counterintuitive workflows, so I've now
changed it so that all cursor-based movement should keep the selected
message visible at all times. However, the old viewport navigation
commands can still pan the viewport without moving the cursor.