### PR TITLE
Add ability to query missing history

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ The keybindings are:
     - enter/i - start a reply to the selected message
     - home/g - jump to top of history
     - end/G - jump to bottom of history
+    - q - query the server for any missing chat history (only necessary if top status bar indicates)
 - Compose Mode:
     - enter - send your message
     - escape - return to history mode

--- a/archive/archive.go
+++ b/archive/archive.go
@@ -45,7 +45,7 @@ func (a *Archive) Needed(n int) []string {
 	}
 	needed := make([]string, 0)
 	for _, m := range a.chronological {
-		if !a.Has(m.Parent) {
+		if m.Parent != "" && !a.Has(m.Parent) {
 			needed = append(needed, m.Parent)
 		}
 	}

--- a/archive/archive.go
+++ b/archive/archive.go
@@ -35,6 +35,26 @@ func (a *Archive) Last(n int) []*arbor.ChatMessage {
 	return a.chronological[len(a.chronological)-n:]
 }
 
+// Needed returns at most `n` message IDs that are referenced as parents within
+// the archive but are not present within the archive. These IDs should be sorted
+// such that the most-recently-referenced parents are returned first. If an empty
+// slice is returned, all messages within the archive have a complete ancestry.
+func (a *Archive) Needed(n int) []string {
+	if n <= 0 {
+		return make([]string, 0)
+	}
+	needed := make([]string, 0)
+	for _, m := range a.chronological {
+		if !a.Has(m.Parent) {
+			needed = append(needed, m.Parent)
+		}
+	}
+	if n >= len(needed) {
+		return needed
+	}
+	return needed[len(a.chronological)-n:]
+}
+
 // Has returns whether the archive contains a message with the given ID.
 func (a *Archive) Has(id string) bool {
 	for _, message := range a.chronological {

--- a/archive/archive_test.go
+++ b/archive/archive_test.go
@@ -285,4 +285,12 @@ func TestNeeded(t *testing.T) {
 	if needed := a.Needed(maliciousLen); len(needed) != 0 {
 		t.Errorf("non-Empty archive returned non-empty slice when length was %d", maliciousLen)
 	}
+	root := message
+	root.Parent = ""
+	addOrSkip(t, a, &root)
+	for _, parent := range a.Needed(10) {
+		if parent == "" {
+			t.Errorf("Should not express the empty string as a needed parent")
+		}
+	}
 }

--- a/tui/interfaces.go
+++ b/tui/interfaces.go
@@ -21,6 +21,7 @@ type Composer interface {
 // Archive stores and retrieves messages
 type Archive interface {
 	Last(n int) []*arbor.ChatMessage
+	Needed(n int) []string
 	Has(id string) bool
 	Get(id string) *arbor.ChatMessage
 	Add(message *arbor.ChatMessage) error

--- a/tui/tui.go
+++ b/tui/tui.go
@@ -181,6 +181,16 @@ func (t *TUI) scrollTop(c *gocui.Gui, v *gocui.View) error {
 	return v.SetOrigin(currentX, 0)
 }
 
+// queryNeeded sends a batch of queries to the server to update the history.
+func (t *TUI) queryNeeded(c *gocui.Gui, v *gocui.View) error {
+	needed := t.histState.Needed(10)
+	log.Println(needed)
+	for _, n := range needed {
+		t.Query(n)
+	}
+	return nil
+}
+
 // reRender forces a redraw of the historyView
 func (t *TUI) reRender() {
 	t.Update(func(g *gocui.Gui) error {
@@ -192,9 +202,9 @@ func (t *TUI) reRender() {
 		needed := t.histState.Needed(100)
 		var suffix string
 		if len(needed) == 0 {
-			suffix = "History complete"
+			suffix = "all known threads complete"
 		} else {
-			suffix = fmt.Sprintf("Need %d+ ancestors, q to query", len(needed))
+			suffix = fmt.Sprintf("%d+ broken threads, q to query", len(needed))
 		}
 		if msg := t.histState.Get(t.histState.Current()); msg != nil {
 			timestamp := time.Unix(msg.Timestamp, 0).Local().Format(time.UnixDate)
@@ -280,6 +290,7 @@ func (t *TUI) layout(gui *gocui.Gui) error {
 		{historyView, 'g', gocui.ModNone, t.scrollTop, "scrollTop"},
 		{historyView, gocui.KeyEnd, gocui.ModNone, t.scrollBottom, "scrollBottom"},
 		{historyView, 'G', gocui.ModNone, t.scrollBottom, "scrollBottom"},
+		{historyView, 'q', gocui.ModNone, t.queryNeeded, "queryNeeded"},
 		{editView, gocui.KeyEnter, gocui.ModNone, t.sendReply, "sendReply"},
 		{editView, gocui.KeyEsc, gocui.ModNone, t.cancelReply, "cancelReply"},
 	}

--- a/tui/tui.go
+++ b/tui/tui.go
@@ -1,6 +1,7 @@
 package tui
 
 import (
+	"fmt"
 	"log"
 	"sync"
 	"time"
@@ -188,9 +189,16 @@ func (t *TUI) reRender() {
 			return err
 		}
 		v.Clear()
+		needed := t.histState.Needed(100)
+		var suffix string
+		if len(needed) == 0 {
+			suffix = "History complete"
+		} else {
+			suffix = fmt.Sprintf("Need %d+ ancestors, q to query", len(needed))
+		}
 		if msg := t.histState.Get(t.histState.Current()); msg != nil {
 			timestamp := time.Unix(msg.Timestamp, 0).Local().Format(time.UnixDate)
-			v.Title = histViewTitlePrefix + " | Selected: " + timestamp
+			v.Title = histViewTitlePrefix + " | Selected: " + timestamp + " | " + suffix
 		}
 		return t.histState.Render(v)
 	})


### PR DESCRIPTION
This adds status about how much history is missing to the chat history title and adds the `q` keybinding to request missing history from the server.

I'm uncertain what the correct long-term approach to querying history is. Not sure if it should always be automatic or not. This is just a first pass.