### PR TITLE
Add reply-to-root keybinding

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ The keybindings are:
     - up/down/j/k - scroll the selected message up and down
     - left/right/h/l - scroll the viewport (not the cursor) up and down
     - enter/i - start a reply to the selected message
+    - r - reply to the earliest known message (the root message)
     - home/g - jump to top of history
     - end/G - jump to bottom of history
     - q - query the server for any missing chat history (only necessary if top status bar indicates)

--- a/tui/tui.go
+++ b/tui/tui.go
@@ -282,6 +282,13 @@ func (t *TUI) composeReply(c *gocui.Gui, v *gocui.View) error {
 	return t.composeMode()
 }
 
+// composeReplyToRoot starts replying to the earliest known message (root, unless something is very wrong).
+func (t *TUI) composeReplyToRoot(c *gocui.Gui, v *gocui.View) error {
+	t.histState.CursorBeginning()
+	t.reRender()
+	return t.composeMode()
+}
+
 // cancelReply exits compose mode and returns to history mode.
 func (t *TUI) cancelReply(c *gocui.Gui, v *gocui.View) error {
 	return t.historyMode()
@@ -320,6 +327,7 @@ func (t *TUI) layout(gui *gocui.Gui) error {
 		{historyView, 'h', gocui.ModNone, t.scrollUp, "scrollUp"},
 		{historyView, gocui.KeyEnter, gocui.ModNone, t.composeReply, "composeReply"},
 		{historyView, 'i', gocui.ModNone, t.composeReply, "composeReply"},
+		{historyView, 'r', gocui.ModNone, t.composeReplyToRoot, "composeReplyToRoot"},
 		{historyView, gocui.KeyHome, gocui.ModNone, t.scrollTop, "scrollTop"},
 		{historyView, 'g', gocui.ModNone, t.scrollTop, "scrollTop"},
 		{historyView, gocui.KeyEnd, gocui.ModNone, t.scrollBottom, "scrollBottom"},


### PR DESCRIPTION
I'd love some feedback on how this works. Pressing `r` is essentially the equivalent of pressing `g` then `Enter`, except the view doesn't scroll. Is that what we want? If not, what's the desired UX?

Closes #40 