### PR TITLE
Send a [quit] message when you close the client

### DIFF
--- a/tui/interfaces.go
+++ b/tui/interfaces.go
@@ -33,6 +33,7 @@ type Archive interface {
 	Needed(n int) []string
 	Has(id string) bool
 	Get(id string) *arbor.ChatMessage
+	Root() (string, error)
 	Add(message *arbor.ChatMessage) error
 	Persist(storage io.Writer) error
 	Load(storage io.Reader) error

--- a/tui/tui.go
+++ b/tui/tui.go
@@ -95,7 +95,7 @@ func (t *TUI) mainLoop() chan struct{} {
 
 		t.SetManagerFunc(t.layout)
 
-		if err := t.SetKeybinding("", gocui.KeyCtrlC, gocui.ModNone, quit); err != nil {
+		if err := t.SetKeybinding("", gocui.KeyCtrlC, gocui.ModNone, t.quit); err != nil {
 			log.Println("Failed registering exit keystroke handler", err)
 		}
 
@@ -136,7 +136,10 @@ func (t *TUI) Display(message *arbor.ChatMessage) {
 
 // quit asks the TUI to stop running. Should only be called as
 // a keystroke or mouse input handler.
-func quit(c *gocui.Gui, v *gocui.View) error {
+func (t *TUI) quit(c *gocui.Gui, v *gocui.View) error {
+	t.histState.CursorBeginning()
+	t.Composer.Reply(t.histState.Current(), "[quit]")
+	time.Sleep(time.Millisecond * 250) // wait in the hope that Quit will be sent
 	return gocui.ErrQuit
 }
 


### PR DESCRIPTION
Right now, I don't have a good way to block when you try to send a message.
Generally, that's the exact opposite of what you want a UI to do. However,
that means that I can't guarantee that the message is actually sent before
destroying the TUI and ending the process. There are better ways to do this,
but they involve more substantial change. One thing at a time.

Closes #42 