### PR TITLE
Relocate interface declarations into subpackage

### DIFF
--- a/client.go
+++ b/client.go
@@ -9,7 +9,7 @@ import (
 
 	arbor "github.com/arborchat/arbor-go"
 	"github.com/arborchat/muscadine/archive"
-	"github.com/arborchat/muscadine/tui"
+	"github.com/arborchat/muscadine/types"
 )
 
 const timeout = 30 * time.Second
@@ -32,7 +32,7 @@ type NetClient struct {
 	address string
 	arbor.ReadWriteCloser
 	connectFunc       Connector
-	disconnectHandler func(tui.Connection)
+	disconnectHandler func(types.Connection)
 	receiveHandler    func(*arbor.ChatMessage)
 	stopSending       chan struct{}
 	stopReceiving     chan struct{}
@@ -76,7 +76,7 @@ func (nc *NetClient) SetConnector(connector Connector) {
 
 // OnDisconnect sets the handler for disconnections. This should be done before
 // calling Connect() for the first time to avoid race conditions.
-func (nc *NetClient) OnDisconnect(handler func(tui.Connection)) {
+func (nc *NetClient) OnDisconnect(handler func(types.Connection)) {
 	nc.disconnectHandler = handler
 }
 

--- a/client_test.go
+++ b/client_test.go
@@ -7,7 +7,7 @@ import (
 
 	arbor "github.com/arborchat/arbor-go"
 	"github.com/arborchat/muscadine/archive"
-	"github.com/arborchat/muscadine/tui"
+	"github.com/arborchat/muscadine/types"
 	"github.com/onsi/gomega"
 )
 
@@ -45,7 +45,7 @@ func TestNetClient(t *testing.T) {
 	g.Expect(err).To(gomega.BeNil())
 
 	nc.SetConnector(bufConnector)
-	nc.OnDisconnect(func(client tui.Connection) {
+	nc.OnDisconnect(func(client types.Connection) {
 		times++
 		timesDisconnected <- times
 	})

--- a/hist-helpers.go
+++ b/hist-helpers.go
@@ -4,10 +4,10 @@ import (
 	"log"
 	"os"
 
-	"github.com/arborchat/muscadine/tui"
+	"github.com/arborchat/muscadine/types"
 )
 
-func loadHist(history tui.Archive, histfile string) {
+func loadHist(history types.Archive, histfile string) {
 	if histfile != "" {
 		file, err := os.Open(histfile)
 		if err != nil {
@@ -22,7 +22,7 @@ func loadHist(history tui.Archive, histfile string) {
 		}
 	}
 }
-func saveHist(history tui.Archive, histfile string) {
+func saveHist(history types.Archive, histfile string) {
 	if histfile != "" {
 		file, err := os.OpenFile(histfile, os.O_RDWR|os.O_CREATE, 0600)
 		if err != nil {

--- a/main.go
+++ b/main.go
@@ -5,21 +5,14 @@ import (
 	"log"
 	"os"
 
-	arbor "github.com/arborchat/arbor-go"
 	"github.com/arborchat/muscadine/archive"
 	"github.com/arborchat/muscadine/tui"
+	"github.com/arborchat/muscadine/types"
 )
-
-// UI is all of the operations that an Arbor client front-end needs to support
-// in order to be a drop-in replacement for the default.
-type UI interface {
-	Display(*arbor.ChatMessage) // adds a chat message to the UI
-	AwaitExit()                 // blocks until UI exit
-}
 
 func main() {
 	var (
-		ui       UI
+		ui       types.UI
 		err      error
 		username string
 		histfile string

--- a/tui/history_state.go
+++ b/tui/history_state.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	arbor "github.com/arborchat/arbor-go"
+	"github.com/arborchat/muscadine/types"
 	"github.com/bbrks/wrap"
 	runewidth "github.com/mattn/go-runewidth"
 )
@@ -17,7 +18,7 @@ type HistoryState struct {
 	// Index 0 holds the oldes messages, and the highest valid index holds the most
 	// recent.
 	History []*arbor.ChatMessage
-	Archive
+	types.Archive
 	renderWidth, renderHeight      int
 	historyHeight                  int
 	current                        string
@@ -42,7 +43,7 @@ const (
 )
 
 // NewHistoryState creates an empty HistoryState ready to be updated.
-func NewHistoryState(a Archive) (*HistoryState, error) {
+func NewHistoryState(a types.Archive) (*HistoryState, error) {
 	if a == nil {
 		return nil, fmt.Errorf("Cannot create HistoryState will nil Archive")
 	}

--- a/tui/tui.go
+++ b/tui/tui.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	arbor "github.com/arborchat/arbor-go"
+	"github.com/arborchat/muscadine/types"
 	"github.com/jroimartin/gocui"
 )
 
@@ -21,7 +22,7 @@ type TUI struct {
 	*gocui.Gui
 	done     chan struct{}
 	messages chan *arbor.ChatMessage
-	Composer
+	types.Composer
 	histState      *HistoryState
 	init           sync.Once
 	editMode       bool
@@ -31,7 +32,7 @@ type TUI struct {
 
 // NewTUI creates a new terminal user interface. The provided channel will be
 // used to relay any protocol messages initiated by the TUI.
-func NewTUI(client Client) (*TUI, error) {
+func NewTUI(client types.Client) (*TUI, error) {
 	gui, err := gocui.NewGui(gocui.OutputNormal)
 	if err != nil {
 		return nil, err
@@ -59,9 +60,9 @@ func NewTUI(client Client) (*TUI, error) {
 // manageConnection handles the actual policy of when to connect from and disconnect
 // from the server. The current implementation tries to connect as soon as possible,
 // then tries to reconnect every 5 seconds if it is disconnected.
-func (t *TUI) manageConnection(c Connection) {
+func (t *TUI) manageConnection(c types.Connection) {
 	disconnected := make(chan struct{})
-	c.OnDisconnect(func(disconn Connection) {
+	c.OnDisconnect(func(disconn types.Connection) {
 		disconnected <- struct{}{}
 	})
 	for {

--- a/types/interfaces.go
+++ b/types/interfaces.go
@@ -1,10 +1,22 @@
-package tui
+// Package types contains the interface and concrete types used for interoperability
+// within all of the modules of muscadine. Wherever possible, we do not rely
+// on a specific implementation of functionality, but rather an interface.
+// Having a separate package that defines those interfaces makes importing
+// them anywhere within the codebase simpler (avoids weird circular imports).
+package types
 
 import (
 	"io"
 
 	arbor "github.com/arborchat/arbor-go"
 )
+
+// UI is all of the operations that an Arbor client front-end needs to support
+// in order to be a drop-in replacement for the default.
+type UI interface {
+	Display(*arbor.ChatMessage) // adds a chat message to the UI
+	AwaitExit()                 // blocks until UI exit
+}
 
 // Client manages the connection between a TUI and a specific server
 type Client interface {


### PR DESCRIPTION
This is some housekeeping that I've been meaning to do for a while. Packages shouldn't import one another *just* to use interfaces definitions, so I gathered the interfaces together into a separate package.