### PR TITLE
Integrate multi-line editor

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,8 @@ The keybindings are:
     - q - query the server for any missing chat history (only necessary if top status bar indicates)
 - Compose Mode:
     - enter - send your message
-    - escape - return to history mode
+    - alt+enter - type a literal newline
+    - ctrl+\ - return to history mode
 - Global:
     - ctrl+c - quit
 

--- a/tui/editor.go
+++ b/tui/editor.go
@@ -59,6 +59,15 @@ func (e *Editor) insertNewline(g *gocui.Gui, v *gocui.View) error {
 	return nil
 }
 
+// insertTab adds a tab character into the editor at the current cursor position.
+func (e *Editor) insertTab(g *gocui.Gui, v *gocui.View) error {
+	v.EditWrite(' ')
+	v.EditWrite(' ')
+	v.EditWrite(' ')
+	v.EditWrite(' ')
+	return nil
+}
+
 // Layout is responsible for setting the desired view dimensions for the
 // Editor, but *not* for setting its position. That is handled by a higher-order
 // layout function.

--- a/tui/editor.go
+++ b/tui/editor.go
@@ -1,0 +1,91 @@
+package tui
+
+import (
+	"github.com/jroimartin/gocui"
+)
+
+const borderHeight = 2
+
+// Editor acts as a controller for an editable gocui.View
+// This editor provides a layout function that will manage its own size,
+// but not its position within the TUI.
+// Its size when empty will be 1 internal row, but will expand as content
+// is added.
+type Editor struct {
+	name    string
+	h       int
+	Title   string
+	ReplyTo string
+	Content string
+}
+
+// NewEditor creates a new controller for an Editor view.
+func NewEditor() *Editor {
+	return &Editor{name: editView, h: borderHeight}
+}
+
+// Focus lets the Editor perform any changes needed when it gains focus. It should
+// always be called from within a gocui.Update function (or similar) so that the
+// changes are rendered immediately
+func (e *Editor) Focus(g *gocui.Gui) error {
+	g.Cursor = true
+	_, err := g.SetCurrentView(e.name)
+	return err
+
+}
+
+// Unfocus lets the Editor perform any changes needed when it loses focus. It should be
+// called under the same conditions as `Focus`.
+func (e *Editor) Unfocus(g *gocui.Gui) error {
+	g.Cursor = false
+	return nil
+}
+
+// Clear erases the current contents of the editor. This should be performed within a gocui.Update
+// context.
+func (e *Editor) Clear(g *gocui.Gui) error {
+	v, err := g.View(e.name)
+	if err != nil {
+		return err
+	}
+	v.Clear()
+	e.Content = ""
+	return nil
+}
+
+// insertNewline adds a newline character into the editor at the current cursor position.
+func (e *Editor) insertNewline(g *gocui.Gui, v *gocui.View) error {
+	v.EditNewLine()
+	return nil
+}
+
+// Layout is responsible for setting the desired view dimensions for the
+// Editor, but *not* for setting its position. That is handled by a higher-order
+// layout function.
+func (e *Editor) Layout(g *gocui.Gui) error {
+	// If the new has already been initialized, update its height to reflect its
+	// current contents
+	if v, err := g.View(e.name); err == nil {
+		lines := len(v.BufferLines())
+		e.h = lines + borderHeight
+		e.Content = v.Buffer()
+	}
+	// Set the view's dimensions
+	width, _ := g.Size()
+	v, err := g.SetView(e.name, 0, 0, width-1, e.h)
+	if err != nil {
+		if err != gocui.ErrUnknownView {
+			return err
+		}
+		// If we are creating the view for the first time, configure its settings
+		v.Editable = true
+		v.Editor = gocui.DefaultEditor
+	}
+	// update the title regardless of whether this is the first-time initialization
+	if e.ReplyTo == "" {
+		v.Title = e.Title
+	} else {
+		v.Title = e.Title + "| replying to " + e.ReplyTo
+	}
+	return nil
+}

--- a/tui/keybindings.go
+++ b/tui/keybindings.go
@@ -1,0 +1,38 @@
+package tui
+
+import "github.com/jroimartin/gocui"
+
+// Binding represents a binding between a keypress and a handler function
+type Binding struct {
+	View        string
+	Key         interface{}
+	Modifier    gocui.Modifier
+	Handler     func(*gocui.Gui, *gocui.View) error
+	HandlerName string
+}
+
+// Keybindings returns the default keybindings
+func (t *TUI) Keybindings() []Binding {
+	return []Binding{
+		{globalView, gocui.KeyCtrlC, gocui.ModNone, t.quit, "quit"},
+		{historyView, gocui.KeyArrowDown, gocui.ModNone, t.cursorDown, "cursorDown"},
+		{historyView, 'j', gocui.ModNone, t.cursorDown, "cursorDown"},
+		{historyView, gocui.KeyArrowRight, gocui.ModNone, t.scrollDown, "scrollDown"},
+		{historyView, 'l', gocui.ModNone, t.scrollDown, "scrollDown"},
+		{historyView, gocui.KeyArrowUp, gocui.ModNone, t.cursorUp, "cursorUp"},
+		{historyView, 'k', gocui.ModNone, t.cursorUp, "cursorUp"},
+		{historyView, gocui.KeyArrowLeft, gocui.ModNone, t.scrollUp, "scrollUp"},
+		{historyView, 'h', gocui.ModNone, t.scrollUp, "scrollUp"},
+		{historyView, gocui.KeyEnter, gocui.ModNone, t.composeReply, "composeReply"},
+		{historyView, 'i', gocui.ModNone, t.composeReply, "composeReply"},
+		{historyView, 'r', gocui.ModNone, t.composeReplyToRoot, "composeReplyToRoot"},
+		{historyView, gocui.KeyHome, gocui.ModNone, t.scrollTop, "scrollTop"},
+		{historyView, 'g', gocui.ModNone, t.scrollTop, "scrollTop"},
+		{historyView, gocui.KeyEnd, gocui.ModNone, t.scrollBottom, "scrollBottom"},
+		{historyView, 'G', gocui.ModNone, t.scrollBottom, "scrollBottom"},
+		{historyView, 'q', gocui.ModNone, t.queryNeeded, "queryNeeded"},
+		{editView, gocui.KeyEnter, gocui.ModAlt, t.Editor.insertNewline, "insertNewline"},
+		{editView, gocui.KeyEnter, gocui.ModNone, t.sendReply, "sendReply"},
+		{editView, gocui.KeyCtrlBackslash, gocui.ModNone, t.cancelReply, "cancelReply"},
+	}
+}

--- a/tui/keybindings.go
+++ b/tui/keybindings.go
@@ -32,6 +32,7 @@ func (t *TUI) Keybindings() []Binding {
 		{historyView, 'G', gocui.ModNone, t.scrollBottom, "scrollBottom"},
 		{historyView, 'q', gocui.ModNone, t.queryNeeded, "queryNeeded"},
 		{editView, gocui.KeyEnter, gocui.ModAlt, t.Editor.insertNewline, "insertNewline"},
+		{editView, gocui.KeyTab, gocui.ModNone, t.Editor.insertTab, "insertTab"},
 		{editView, gocui.KeyEnter, gocui.ModNone, t.sendReply, "sendReply"},
 		{editView, gocui.KeyCtrlBackslash, gocui.ModNone, t.cancelReply, "cancelReply"},
 	}

--- a/tui/keybindings.go
+++ b/tui/keybindings.go
@@ -31,8 +31,8 @@ func (t *TUI) Keybindings() []Binding {
 		{historyView, gocui.KeyEnd, gocui.ModNone, t.scrollBottom, "scrollBottom"},
 		{historyView, 'G', gocui.ModNone, t.scrollBottom, "scrollBottom"},
 		{historyView, 'q', gocui.ModNone, t.queryNeeded, "queryNeeded"},
-		{editView, gocui.KeyEnter, gocui.ModAlt, t.Editor.insertNewline, "insertNewline"},
-		{editView, gocui.KeyTab, gocui.ModNone, t.Editor.insertTab, "insertTab"},
+		{editView, gocui.KeyEnter, gocui.ModAlt, t.Editor.ActionInsertNewline, "InsertNewline"},
+		{editView, gocui.KeyTab, gocui.ModNone, t.Editor.ActionInsertTab, "InsertTab"},
 		{editView, gocui.KeyEnter, gocui.ModNone, t.sendReply, "sendReply"},
 		{editView, gocui.KeyCtrlBackslash, gocui.ModNone, t.cancelReply, "cancelReply"},
 	}

--- a/tui/layout.go
+++ b/tui/layout.go
@@ -1,0 +1,47 @@
+package tui
+
+import "github.com/jroimartin/gocui"
+
+// BottomPrimaryLayout manages two gocui.Views within a gocui.Gui by respecting the size
+// requests of the bottom view at the expense of the size of the top. The bottom view will
+// be positioned at the bottom of the Gui, regardless of whatever internal position it may
+// have requested. The bottom view will also be prevented from exapanding beyond half of the
+// available screen real-estate.
+//
+// Note that BottomPrimaryLayout returns a Layout function, so proper usage is:
+// ```
+// manager := gocui.ManagerFunc(BottomPrimaryLayout("bottom-view-name", "top-view-name"))
+// ```
+func BottomPrimaryLayout(topView, bottomView string) func(*gocui.Gui) error {
+	return func(g *gocui.Gui) error {
+		// ensure both of our target view exist
+		bottom, err := g.View(bottomView)
+		if err != nil {
+			return err
+		}
+		_, err = g.View(topView)
+		if err != nil {
+			return err
+		}
+
+		// check the size of the top view and make sure it's reasonable
+		maxX, maxY := g.Size()
+		_, bottomHeight := bottom.Size()
+		if bottomHeight > maxY/2 {
+			bottomHeight = maxY / 2
+		}
+
+		// configure the position and size of the bottom view
+		bottomPosY := maxY - bottomHeight - 2
+		if _, err = g.SetView(bottomView, 0, bottomPosY, maxX-1, maxY-1); err != nil {
+			return err
+		}
+
+		// configure the position and size of the top view
+		topHeight := bottomPosY - 1
+		if _, err = g.SetView(topView, 0, 0, maxX-1, topHeight); err != nil {
+			return err
+		}
+		return nil
+	}
+}

--- a/tui/tui.go
+++ b/tui/tui.go
@@ -273,7 +273,7 @@ func (t *TUI) reRender() {
 // historyMode transitions the TUI to interactively scroll the history.
 // All state change related to that transition should be defined here.
 func (t *TUI) historyMode() error {
-	err := t.Editor.Unfocus(t.Gui)
+	err := t.Editor.Unfocus()
 	if err != nil {
 		return err
 	}
@@ -287,7 +287,7 @@ func (t *TUI) historyMode() error {
 // composeMode transitions the TUI to interactively editing messages.
 // All state change related to that transition should be defined here.
 func (t *TUI) composeMode(replyTo *arbor.ChatMessage) error {
-	return t.Editor.Focus(t.Gui, replyTo)
+	return t.Editor.Focus(replyTo)
 }
 
 // composeReply starts replying to the current message.

--- a/tui/tui.go
+++ b/tui/tui.go
@@ -14,8 +14,6 @@ import (
 const historyView = "history"
 const editView = "edit"
 const globalView = ""
-const preEditViewTitle = "Arrows to select, hit enter to reply"
-const midEditViewTitle = "Type your reply, hit enter to send"
 const histViewTitlePrefix = "Chat History"
 
 // TUI is the default terminal user interface implementation for this client
@@ -288,20 +286,24 @@ func (t *TUI) historyMode() error {
 
 // composeMode transitions the TUI to interactively editing messages.
 // All state change related to that transition should be defined here.
-func (t *TUI) composeMode() error {
-	return t.Editor.Focus(t.Gui)
+func (t *TUI) composeMode(replyTo *arbor.ChatMessage) error {
+	return t.Editor.Focus(t.Gui, replyTo)
 }
 
 // composeReply starts replying to the current message.
 func (t *TUI) composeReply(c *gocui.Gui, v *gocui.View) error {
-	return t.composeMode()
+	msg := t.histState.Get(t.histState.Current())
+	return t.composeMode(msg)
 }
 
 // composeReplyToRoot starts replying to the earliest known message (root, unless something is very wrong).
 func (t *TUI) composeReplyToRoot(c *gocui.Gui, v *gocui.View) error {
-	t.histState.CursorBeginning()
-	t.reRender()
-	return t.composeMode()
+	root, err := t.histState.Root()
+	if err != nil {
+		return err
+	}
+	rootMsg := t.histState.Get(root)
+	return t.composeMode(rootMsg)
 }
 
 // cancelReply exits compose mode and returns to history mode.
@@ -319,7 +321,7 @@ func (t *TUI) sendReply(c *gocui.Gui, v *gocui.View) error {
 	v.Clear()
 	v.SetCursor(0, 0)
 	v.SetOrigin(0, 0)
-	t.Composer.Reply(t.histState.Current(), content[:len(content)-1])
+	t.Composer.Reply(t.Editor.ReplyTo.UUID, content[:len(content)-1])
 	return t.historyMode()
 }
 

--- a/tui/tui.go
+++ b/tui/tui.go
@@ -13,6 +13,7 @@ import (
 
 const historyView = "history"
 const editView = "edit"
+const globalView = ""
 const preEditViewTitle = "Arrows to select, hit enter to reply"
 const midEditViewTitle = "Type your reply, hit enter to send"
 const histViewTitlePrefix = "Chat History"
@@ -23,6 +24,7 @@ type TUI struct {
 	done     chan struct{}
 	messages chan *arbor.ChatMessage
 	types.Composer
+	*Editor
 	histState      *HistoryState
 	init           sync.Once
 	editMode       bool
@@ -37,7 +39,7 @@ func NewTUI(client types.Client) (*TUI, error) {
 	if err != nil {
 		return nil, err
 	}
-	gui.InputEsc = true
+	//gui.InputEsc = true
 	hs, err := NewHistoryState(client)
 	if err != nil {
 		return nil, err
@@ -48,6 +50,7 @@ func NewTUI(client types.Client) (*TUI, error) {
 		messages:  make(chan *arbor.ChatMessage),
 		histState: hs,
 		Composer:  client,
+		Editor:    NewEditor(),
 	}
 	client.OnReceive(t.Display)
 	t.done = t.mainLoop()
@@ -104,10 +107,14 @@ func (t *TUI) mainLoop() chan struct{} {
 		defer close(done)
 		defer t.Close()
 
-		t.SetManagerFunc(t.layout)
+		makeHist := gocui.ManagerFunc(t.layout)
+		layout := gocui.ManagerFunc(BottomPrimaryLayout(historyView, editView))
+		t.SetManager(t.Editor, makeHist, layout)
 
-		if err := t.SetKeybinding("", gocui.KeyCtrlC, gocui.ModNone, t.quit); err != nil {
-			log.Println("Failed registering exit keystroke handler", err)
+		for _, binding := range t.Keybindings() {
+			if err := t.SetKeybinding(binding.View, binding.Key, binding.Modifier, binding.Handler); err != nil {
+				log.Printf("Failed registering %s keystroke handler on view %v: %s\n", binding.HandlerName, binding.View, err)
+			}
 		}
 
 		if err := t.MainLoop(); err != nil && err != gocui.ErrQuit {
@@ -268,12 +275,10 @@ func (t *TUI) reRender() {
 // historyMode transitions the TUI to interactively scroll the history.
 // All state change related to that transition should be defined here.
 func (t *TUI) historyMode() error {
-	t.Gui.Cursor = false
-	v, err := t.Gui.View(editView)
+	err := t.Editor.Unfocus(t.Gui)
 	if err != nil {
 		return err
 	}
-	v.Title = preEditViewTitle
 	_, err = t.Gui.SetCurrentView(historyView)
 	if err != nil {
 		return err
@@ -284,14 +289,7 @@ func (t *TUI) historyMode() error {
 // composeMode transitions the TUI to interactively editing messages.
 // All state change related to that transition should be defined here.
 func (t *TUI) composeMode() error {
-	t.Gui.Cursor = true
-	v, err := t.Gui.SetCurrentView(editView)
-	if err != nil {
-		return err
-	}
-	v.Title = midEditViewTitle
-	return nil
-
+	return t.Editor.Focus(t.Gui)
 }
 
 // composeReply starts replying to the current message.
@@ -327,32 +325,6 @@ func (t *TUI) sendReply(c *gocui.Gui, v *gocui.View) error {
 
 // layout places views in the UI.
 func (t *TUI) layout(gui *gocui.Gui) error {
-	keybindings := []struct {
-		View        string
-		Key         interface{}
-		Modifier    gocui.Modifier
-		Handler     func(*gocui.Gui, *gocui.View) error
-		HandlerName string
-	}{
-		{historyView, gocui.KeyArrowDown, gocui.ModNone, t.cursorDown, "cursorDown"},
-		{historyView, 'j', gocui.ModNone, t.cursorDown, "cursorDown"},
-		{historyView, gocui.KeyArrowRight, gocui.ModNone, t.scrollDown, "scrollDown"},
-		{historyView, 'l', gocui.ModNone, t.scrollDown, "scrollDown"},
-		{historyView, gocui.KeyArrowUp, gocui.ModNone, t.cursorUp, "cursorUp"},
-		{historyView, 'k', gocui.ModNone, t.cursorUp, "cursorUp"},
-		{historyView, gocui.KeyArrowLeft, gocui.ModNone, t.scrollUp, "scrollUp"},
-		{historyView, 'h', gocui.ModNone, t.scrollUp, "scrollUp"},
-		{historyView, gocui.KeyEnter, gocui.ModNone, t.composeReply, "composeReply"},
-		{historyView, 'i', gocui.ModNone, t.composeReply, "composeReply"},
-		{historyView, 'r', gocui.ModNone, t.composeReplyToRoot, "composeReplyToRoot"},
-		{historyView, gocui.KeyHome, gocui.ModNone, t.scrollTop, "scrollTop"},
-		{historyView, 'g', gocui.ModNone, t.scrollTop, "scrollTop"},
-		{historyView, gocui.KeyEnd, gocui.ModNone, t.scrollBottom, "scrollBottom"},
-		{historyView, 'G', gocui.ModNone, t.scrollBottom, "scrollBottom"},
-		{historyView, 'q', gocui.ModNone, t.queryNeeded, "queryNeeded"},
-		{editView, gocui.KeyEnter, gocui.ModNone, t.sendReply, "sendReply"},
-		{editView, gocui.KeyEsc, gocui.ModNone, t.cancelReply, "cancelReply"},
-	}
 	mX, mY := gui.Size()
 	histMaxX := mX - 1
 	histMaxY := mY - 1
@@ -371,34 +343,8 @@ func (t *TUI) layout(gui *gocui.Gui) error {
 		// if you reach this point, you are initializing the view for the first time
 		histView.Title = "Chat History"
 
-		for _, binding := range keybindings {
-			if binding.View == historyView {
-				if err := t.SetKeybinding(binding.View, binding.Key, binding.Modifier, binding.Handler); err != nil {
-					log.Printf("Failed registering %s keystroke handler: %v\n", binding.HandlerName, err)
-				}
-			}
-		}
 		if _, err := t.SetCurrentView(historyView); err != nil {
 			log.Println("Failed to set historyView focus", err)
-		}
-	}
-
-	// update view dimensions or create for the first time
-	if v, err := gui.SetView(editView, 0, histMaxY+1, histMaxX, mY-1); err != nil {
-		if err != gocui.ErrUnknownView {
-			log.Println("Error creating editView", err)
-		}
-		// if you reach this point, you are initializing the view for the first time
-		v.Editable = true
-		v.Editor = gocui.DefaultEditor
-		v.Title = preEditViewTitle
-
-		for _, binding := range keybindings {
-			if binding.View == editView {
-				if err := t.SetKeybinding(binding.View, binding.Key, binding.Modifier, binding.Handler); err != nil {
-					log.Printf("Failed registering %s keystroke handler: %v\n", binding.HandlerName, err)
-				}
-			}
 		}
 	}
 


### PR DESCRIPTION
This commit brings together a lot of functionality and refactoring work.

Firstly, it begins the removal of view-specific logic from the TUI struct.
Each view should really have a Controller-like entity managing its internal
state. Editor begins that process, but there's a ways to go yet on cleaning
up the mess in TUI.

Secondly, this commit adds a new layout function that constrains the height of
the chat history by the height of the editor. I anticipate that this will get
complicated quickly in the future as we add more views, but right now it's
pleasantly simple.

Thirdly, this commit changes a default keybinding. I'm very sad about this, but
I feel that I have no choice. In order to get "add a new line to my message" to
work with Alt+Enter, we had to disable the ability to interpret the escape key
as an individual keypress. Because of this, breaking out of the editor is now
Ctrl+\. I'm open to suggestions if anyone has better ideas for this.

There's still work to be done on integrating the Editor. We lost the helpful
title messages that it used to have in this commit, and it is now capable of
managing the message that it's replying to as internal state instead of needing
to use whatever is under the cursor. I think I'll need to add these features
before merging.