### PR TITLE
Remove unneeded dependencies

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -34,22 +34,6 @@
   version = "v5.0"
 
 [[projects]]
-  branch = "master"
-  digest = "1:f14d1b50e0075fb00177f12a96dd7addf93d1e2883c25befd17285b779549795"
-  name = "github.com/gopherjs/gopherjs"
-  packages = ["js"]
-  pruneopts = "UT"
-  revision = "d547d1d9531ed93dbdebcbff7f83e7c876a1e0ee"
-
-[[projects]]
-  digest = "1:0b226f71747698cd3b03156781c849c3df46e229eef5c3682e182558cf34e8f0"
-  name = "github.com/gopherjs/gopherwasm"
-  packages = ["js"]
-  pruneopts = "UT"
-  revision = "b0e1786f520333e4546f02930c5ca8a929b38841"
-  version = "v1.0.1"
-
-[[projects]]
   digest = "1:114ecad51af93a73ae6781fd0d0bc28e52b433c852b84ab4b4c109c15e6c6b6d"
   name = "github.com/jroimartin/gocui"
   packages = ["."]


### PR DESCRIPTION
At some point we accidentally started depending on the Go->JS and Go->WebAssembly compilers. These do not appear to be needed anymore, so this PR removes them from our dependency lock file.