### PR TITLE
Automatically query parents

### DIFF
--- a/client.go
+++ b/client.go
@@ -178,10 +178,15 @@ func (nc *NetClient) readChannel() chan struct {
 func (nc *NetClient) handleMessage(m *arbor.ProtocolMessage) {
 	switch m.Type {
 	case arbor.NewMessageType:
-		if nc.receiveHandler != nil {
-			nc.receiveHandler(m.ChatMessage)
-			// ask notificationEngine to display the message
-			notificationEngine(nc, m.ChatMessage)
+		if !nc.Archive.Has(m.UUID) {
+			if nc.receiveHandler != nil {
+				nc.receiveHandler(m.ChatMessage)
+				// ask notificationEngine to display the message
+				notificationEngine(nc, m.ChatMessage)
+			}
+			if !nc.Archive.Has(m.Parent) {
+				nc.Query(m.Parent)
+			}
 		}
 	case arbor.WelcomeType:
 		if !nc.Has(m.Root) {


### PR DESCRIPTION
This modifies the client so that it *always* queries when it encounters a parent message ID that it doesn't have locally. No more pressing `q` to get your history!