### PR TITLE
Compose editor

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -34,12 +34,20 @@
   version = "v5.0"
 
 [[projects]]
-  digest = "1:114ecad51af93a73ae6781fd0d0bc28e52b433c852b84ab4b4c109c15e6c6b6d"
-  name = "github.com/jroimartin/gocui"
-  packages = ["."]
+  branch = "master"
+  digest = "1:f14d1b50e0075fb00177f12a96dd7addf93d1e2883c25befd17285b779549795"
+  name = "github.com/gopherjs/gopherjs"
+  packages = ["js"]
   pruneopts = "UT"
-  revision = "c055c87ae801372cd74a0839b972db4f7697ae5f"
-  version = "v0.4.0"
+  revision = "d547d1d9531ed93dbdebcbff7f83e7c876a1e0ee"
+
+[[projects]]
+  digest = "1:0b226f71747698cd3b03156781c849c3df46e229eef5c3682e182558cf34e8f0"
+  name = "github.com/gopherjs/gopherwasm"
+  packages = ["js"]
+  pruneopts = "UT"
+  revision = "b0e1786f520333e4546f02930c5ca8a929b38841"
+  version = "v1.0.1"
 
 [[projects]]
   digest = "1:f2ffb104978341aadea72e33f375d42c5e1954f3f6f489f2950b18a4a494cff3"
@@ -122,6 +130,14 @@
   version = "v0.8.0"
 
 [[projects]]
+  branch = "flush-fix-paste"
+  digest = "1:235bbcd980b35106712f2382a10f833e1eeb3128ab0b13e3ad20d84cb6e766fe"
+  name = "github.com/whereswaldon/gocui"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "101990862c62b1156b5f048c02eb2ddf7cdbe1e6"
+
+[[projects]]
   branch = "master"
   digest = "1:5193d913046443e59093d66a97a40c51f4a5ea4ceba60f3b3ecf89694de5d16f"
   name = "golang.org/x/net"
@@ -193,10 +209,10 @@
     "github.com/arborchat/arbor-go",
     "github.com/bbrks/wrap",
     "github.com/gen2brain/beeep",
-    "github.com/jroimartin/gocui",
     "github.com/mattn/go-runewidth",
     "github.com/multiformats/go-multicodec/json",
     "github.com/onsi/gomega",
+    "github.com/whereswaldon/gocui",
   ]
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -34,8 +34,8 @@
   version = "2.3.0"
 
 [[constraint]]
-  name = "github.com/jroimartin/gocui"
-  version = "0.4.0"
+  name = "github.com/whereswaldon/gocui"
+  branch = "flush-fix-paste"
 
 [[constraint]]
   name = "github.com/mattn/go-runewidth"

--- a/README.md
+++ b/README.md
@@ -53,8 +53,8 @@ The keybindings are:
     - end/G - jump to bottom of history
     - q - query the server for any missing chat history (only necessary if top status bar indicates)
 - Compose Mode:
-    - enter - send your message
-    - alt+enter - type a literal newline
+    - enter - send your message (unless in paste mode)
+    - ctrl+p - toggle "paste mode", in which the enter key will *not* send the message, but instead type a newline
     - ctrl+\ - return to history mode
 - Global:
     - ctrl+c - quit

--- a/tui/editor.go
+++ b/tui/editor.go
@@ -2,7 +2,7 @@ package tui
 
 import (
 	arbor "github.com/arborchat/arbor-go"
-	"github.com/jroimartin/gocui"
+	"github.com/whereswaldon/gocui"
 )
 
 const borderHeight = 2
@@ -102,8 +102,9 @@ func (e *Editor) Layout(g *gocui.Gui) error {
 		}
 		// If we are creating the view for the first time, configure its settings
 		v.Editable = true
-		v.Editor = gocui.DefaultEditor
+		v.Editor = &EditCore{}
 		v.Frame = true
+		v.Wrap = false
 	}
 	// update the title regardless of whether this is the first-time initialization
 	if e.ReplyTo == nil {
@@ -125,4 +126,34 @@ func (e *Editor) Layout(g *gocui.Gui) error {
 		e.clear = false
 	}
 	return nil
+}
+
+type EditCore struct {
+}
+
+// Edit handles a single keypress in the editor
+// This is a modification of gocui's simpleEditor function.
+func (e *EditCore) Edit(v *gocui.View, key gocui.Key, ch rune, mod gocui.Modifier) {
+	switch {
+	case ch != 0 && mod == 0:
+		v.EditWrite(ch)
+	case key == gocui.KeySpace:
+		v.EditWrite(' ')
+	case key == gocui.KeyBackspace || key == gocui.KeyBackspace2:
+		v.EditDelete(true)
+	case key == gocui.KeyDelete:
+		v.EditDelete(false)
+	case key == gocui.KeyInsert:
+		v.Overwrite = !v.Overwrite
+	case key == gocui.KeyEnter:
+		v.EditNewLine()
+	case key == gocui.KeyArrowDown:
+		v.MoveCursor(0, 1, false)
+	case key == gocui.KeyArrowUp:
+		v.MoveCursor(0, -1, false)
+	case key == gocui.KeyArrowLeft:
+		v.MoveCursor(-1, 0, false)
+	case key == gocui.KeyArrowRight:
+		v.MoveCursor(1, 0, false)
+	}
 }

--- a/tui/keybindings.go
+++ b/tui/keybindings.go
@@ -31,9 +31,9 @@ func (t *TUI) Keybindings() []Binding {
 		{historyView, gocui.KeyEnd, gocui.ModNone, t.scrollBottom, "scrollBottom"},
 		{historyView, 'G', gocui.ModNone, t.scrollBottom, "scrollBottom"},
 		{historyView, 'q', gocui.ModNone, t.queryNeeded, "queryNeeded"},
-		{editView, gocui.KeyEnter, gocui.ModAlt, t.Editor.ActionInsertNewline, "InsertNewline"},
 		{editView, gocui.KeyTab, gocui.ModNone, t.Editor.ActionInsertTab, "InsertTab"},
-		{editView, gocui.KeyEnter, gocui.ModNone, t.sendReply, "sendReply"},
+		{editView, gocui.KeyEnter, gocui.ModNone, t.handleEnter, "handleEnter"},
 		{editView, gocui.KeyCtrlBackslash, gocui.ModNone, t.cancelReply, "cancelReply"},
+		{editView, gocui.KeyCtrlP, gocui.ModNone, t.Editor.ActionTogglePasteMode, "TogglePasteMode"},
 	}
 }

--- a/tui/keybindings.go
+++ b/tui/keybindings.go
@@ -1,6 +1,6 @@
 package tui
 
-import "github.com/jroimartin/gocui"
+import "github.com/whereswaldon/gocui"
 
 // Binding represents a binding between a keypress and a handler function
 type Binding struct {

--- a/tui/layout.go
+++ b/tui/layout.go
@@ -1,6 +1,6 @@
 package tui
 
-import "github.com/jroimartin/gocui"
+import "github.com/whereswaldon/gocui"
 
 // BottomPrimaryLayout manages two gocui.Views within a gocui.Gui by respecting the size
 // requests of the bottom view at the expense of the size of the top. The bottom view will

--- a/tui/tui.go
+++ b/tui/tui.go
@@ -8,7 +8,7 @@ import (
 
 	arbor "github.com/arborchat/arbor-go"
 	"github.com/arborchat/muscadine/types"
-	"github.com/jroimartin/gocui"
+	"github.com/whereswaldon/gocui"
 )
 
 const historyView = "history"

--- a/tui/tui.go
+++ b/tui/tui.go
@@ -311,6 +311,17 @@ func (t *TUI) cancelReply(c *gocui.Gui, v *gocui.View) error {
 	return t.historyMode()
 }
 
+// handleEnter is intended to be used *only* for handling the "Enter" keypress. It allows the Editor
+// to dictate whether or not the keypress should be interpreted literally. The results of that
+// decision must be handled by the TUI as a whole, since only the TUI can actually perform the
+// sendReply action if that key should not be literal.
+func (t *TUI) handleEnter(c *gocui.Gui, v *gocui.View) error {
+	if t.Editor.EnterIsLiteral() {
+		return t.Editor.ActionInsertNewline(c, v)
+	}
+	return t.sendReply(c, v)
+}
+
 // sendReply starts replying to the current message.
 func (t *TUI) sendReply(c *gocui.Gui, v *gocui.View) error {
 	content := v.Buffer()


### PR DESCRIPTION
Depends on #56, implements a "paste mode" in the editor so that you can type/paste messages that contain newlines. The paste-mode keybinding is Ctrl+P.