### PR TITLE
Adding issue and PR tempaltes for bug reports and feature requests.

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -1,0 +1,24 @@
+---
+title: 'Bug report'
+labels: bug
+---
+
+## Expected Behavior
+
+1.
+1.
+1.
+
+
+## Current Behavior
+
+1.
+1.
+1.
+
+
+## Other Observations
+
+-
+-
+

--- a/.github/ISSUE_TEMPLATE/feature-request.md
+++ b/.github/ISSUE_TEMPLATE/feature-request.md
@@ -1,0 +1,24 @@
+---
+title: 'Feature Request'
+labels: enhancement
+---
+
+## Story
+
+As a `user`
+I want `this feature`
+so that `it does a thing.`
+
+
+## Feature Explanation
+
+
+## Use-cases
+
+Example use-cases addressed by this feature.
+
+-
+-
+-
+
+

--- a/.github/PULL_REQUEST_TEMPLATE/pr-bugfix.md
+++ b/.github/PULL_REQUEST_TEMPLATE/pr-bugfix.md
@@ -1,0 +1,15 @@
+---
+title: 'Bug Fix'
+labels: bug
+---
+
+Fixes # .
+
+
+Changes proposed:
+
+- 
+- 
+- 
+
+

--- a/.github/PULL_REQUEST_TEMPLATE/pr-bugfix.md
+++ b/.github/PULL_REQUEST_TEMPLATE/pr-bugfix.md
@@ -5,6 +5,11 @@ labels: bug
 
 Fixes # .
 
+Erase all that do not apply:
+- This PR modified command line flags/arguments
+- This PR modified configuration file options
+- This PR modified keybindings (either changing defaults or adding new actions)
+- This PR modified the visible UI
 
 Changes proposed:
 

--- a/.github/PULL_REQUEST_TEMPLATE/pr-feature.md
+++ b/.github/PULL_REQUEST_TEMPLATE/pr-feature.md
@@ -5,6 +5,11 @@ labels: enhancement
 
 Implements # .
 
+Erase all that do not apply:
+- This PR modified command line flags/arguments
+- This PR modified configuration file options
+- This PR modified keybindings (either changing defaults or adding new actions)
+- This PR modified the visible UI
 
 ## Feature explanation
 

--- a/.github/PULL_REQUEST_TEMPLATE/pr-feature.md
+++ b/.github/PULL_REQUEST_TEMPLATE/pr-feature.md
@@ -1,0 +1,12 @@
+---
+title: 'Feature Implementation'
+labels: enhancement
+---
+
+Implements # .
+
+
+## Feature explanation
+
+
+


### PR DESCRIPTION
With more folks adding bug reports and feature requests, we need to make it easier to submit these types of issues to the repo. This PR creates these templates for Issues and PRs. The templates also assign the relevant labels. 