### PR TITLE
Fix panic when querying

### DIFF
--- a/archive/archive.go
+++ b/archive/archive.go
@@ -53,7 +53,7 @@ func (a *Archive) Needed(n int) []string {
 	if n >= len(needed) {
 		return needed
 	}
-	return needed[len(a.chronological)-n:]
+	return needed[len(needed)-n:]
 }
 
 // Has returns whether the archive contains a message with the given ID.


### PR DESCRIPTION
I implemented a regression test to reproduce the problem, then fixed the code to pass it. I think this is a simple mistake that I made back when I first wrote the archive. Thanks for reporting it!

Closes #61