### PR TITLE
Switch back to using ESC to cancel messages

### DIFF
--- a/tui/keybindings.go
+++ b/tui/keybindings.go
@@ -34,7 +34,7 @@ func (t *TUI) Keybindings() []Binding {
 		{historyView, 'q', gocui.ModNone, t.queryNeeded, "queryNeeded"},
 		{editView, gocui.KeyTab, gocui.ModNone, t.Editor.ActionInsertTab, "InsertTab"},
 		{editView, gocui.KeyEnter, gocui.ModNone, t.handleEnter, "handleEnter"},
-		{editView, gocui.KeyCtrlBackslash, gocui.ModNone, t.cancelReply, "cancelReply"},
+		{editView, gocui.KeyEsc, gocui.ModNone, t.cancelReply, "cancelReply"},
 		{editView, gocui.KeyCtrlP, gocui.ModNone, t.Editor.ActionTogglePasteMode, "TogglePasteMode"},
 	}
 }

--- a/tui/tui.go
+++ b/tui/tui.go
@@ -37,7 +37,7 @@ func NewTUI(client types.Client) (*TUI, error) {
 	if err != nil {
 		return nil, err
 	}
-	//gui.InputEsc = true
+	gui.InputEsc = true
 	hs, err := NewHistoryState(client)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Our current choice, Ctrl+\\, doesn't work properly over SSH and is annoying to type. Now that we no longer rely on alt-based key chords, ESC really does make sense.