### PR TITLE
Fix annoying multiple [join] messages

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -2,12 +2,12 @@
 
 
 [[projects]]
-  digest = "1:75f2fb6de78273227510c14c9ec74840e9bb4a717a830abcbf5c56d6bfb755d5"
+  digest = "1:8daee056790af778375e4ebfd492231e109a253d5350d4d375cbf0e92bfe7ec7"
   name = "github.com/arborchat/arbor-go"
   packages = ["."]
   pruneopts = "UT"
-  revision = "d020ea259f6c238f03ede9b9002903d86fbfb9f1"
-  version = "v0.1.6"
+  revision = "c121d4db43986e9e0028225f0ac4a426eea2b89b"
+  version = "v0.1.7"
 
 [[projects]]
   digest = "1:18651a61ae4ba9ee396e0a2fb1882b5f69e6a5b52ee3432f4d7718496f7e857d"

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -2,12 +2,12 @@
 
 
 [[projects]]
-  digest = "1:8daee056790af778375e4ebfd492231e109a253d5350d4d375cbf0e92bfe7ec7"
+  digest = "1:a5a90388171ad62c877b390c08cafe2fa1c311840962cea042e262f8723a545e"
   name = "github.com/arborchat/arbor-go"
   packages = ["."]
   pruneopts = "UT"
-  revision = "c121d4db43986e9e0028225f0ac4a426eea2b89b"
-  version = "v0.1.7"
+  revision = "df1b4b625322732a2e6da2bac8ddb683808858e3"
+  version = "v0.1.8"
 
 [[projects]]
   digest = "1:18651a61ae4ba9ee396e0a2fb1882b5f69e6a5b52ee3432f4d7718496f7e857d"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -27,7 +27,7 @@
 
 [[constraint]]
   name = "github.com/arborchat/arbor-go"
-  version = "0.1.3"
+  version = "0.1.7"
 
 [[constraint]]
   name = "github.com/bbrks/wrap"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -27,7 +27,7 @@
 
 [[constraint]]
   name = "github.com/arborchat/arbor-go"
-  version = "0.1.7"
+  version = "0.1.8"
 
 [[constraint]]
   name = "github.com/bbrks/wrap"

--- a/client.go
+++ b/client.go
@@ -184,7 +184,7 @@ func (nc *NetClient) handleMessage(m *arbor.ProtocolMessage) {
 				// ask notificationEngine to display the message
 				notificationEngine(nc, m.ChatMessage)
 			}
-			if !nc.Archive.Has(m.Parent) {
+			if m.Parent != "" && !nc.Archive.Has(m.Parent) {
 				nc.Query(m.Parent)
 			}
 		}


### PR DESCRIPTION
The client was getting into a disconnect/reconnect loop that spawned absurd numbers of `[join]` messages. This was a problem with validation logic in `arbor-go` and with sending an erroneous query in `muscadine`.

This PR updates muscadine to depend on a fixed version of `arbor-go`, and prevents the illegal query from muscadine.