### PR TITLE
Ensure code compiles on all supported platforms

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,3 +5,4 @@ install:
     - dep ensure
 script:
     - go test -v -cover ./...
+    - for os in linux darwin windows openbsd; do echo "building for $os" && env GOOS="$os" go build -o /dev/null; done


### PR DESCRIPTION
This PR makes TravisCI attempt to build our code for windows, darwin, linux, and openbsd after every change, which should prevent us from being unaware when compilation fails on a specific supported OS (e.g. @Caton101 realizing that I broke the build on Windows).

I did not include dragonflybsd, freebsd, or netbsd because they all failed to compile one of our dependencies. It looks like we might not be able to support them and also rely on `godbus`. I think that's probably a separate discussion though.