### PR TITLE
Add Session Tracking package

### DIFF
--- a/session/list.go
+++ b/session/list.go
@@ -1,6 +1,10 @@
 package session
 
-import "time"
+import (
+	"fmt"
+	"sort"
+	"time"
+)
 
 // Session represents known login sessions of other users. The Id
 // field is unique per session, and LastSeen is the most recent
@@ -12,29 +16,86 @@ type Session struct {
 
 // List represents the known active user sessions on an arbor server.
 type List struct {
-	Active map[string][]*Session
+	Active map[string]map[string]time.Time
 }
 
 // NewList creates an empty list of sessions.
 func NewList() *List {
-	return &List{make(map[string][]*Session)}
+	return &List{make(map[string]map[string]time.Time)}
 }
 
 // Add updates the List with the given session information for the given
 // user. If the user has a session with the same ID already, the LastSeen
 // time is updated to reflect the LastSeen time in sess.
 func (l *List) Add(username string, sess Session) error {
+	if username == "" || sess.ID == "" {
+		return fmt.Errorf("Invalid username (%s) or session ID (%s)", username, sess.ID)
+	}
+	userSessions, present := l.Active[username]
+	if present {
+		// search the existing sessions for the user
+		lastSeen, exists := userSessions[sess.ID]
+		if exists {
+			// update the timestamp if we found the same session
+			if lastSeen.Before(sess.LastSeen) {
+				userSessions[sess.ID] = sess.LastSeen
+			}
+			return nil
+		}
+		// insert the session if it wasn't present
+		l.Active[username][sess.ID] = sess.LastSeen
+		return nil
+	}
+	// user has no sessions, create this one for them
+	userSessions = make(map[string]time.Time)
+	userSessions[sess.ID] = sess.LastSeen
+	l.Active[username] = userSessions
+
 	return nil
 }
 
 // Remove takes the session with ID sessID out of the List for the user
 // with username.
 func (l *List) Remove(username, sessID string) error {
-	return nil
+	if username == "" || sessID == "" {
+		return fmt.Errorf("Invalid username (%s) or session ID (%s)", username, sessID)
+	}
+	userSessions, present := l.Active[username]
+	if present {
+		// search the existing sessions for the user
+		_, exists := userSessions[sessID]
+		if exists {
+			// delete the session if we found it
+			delete(userSessions, sessID)
+			// TODO: delete the whole map for the user if this was their only session
+			return nil
+		}
+		// we were asked to delete a nonexistent session
+		return fmt.Errorf("Can't delete nonexistent session (%s) for user (%s)", sessID, username)
+	}
+	// user has no sessions
+	return fmt.Errorf("Can't delete session (%s) for user (%s), user has no sessions", sessID, username)
 }
 
 // ActiveSessions returns a map from usernames to the most active session
 // for each user.
 func (l *List) ActiveSessions() map[string]*Session {
-	return nil
+	activeMap := make(map[string]*Session)
+	for user, sessionMap := range l.Active {
+		// make a list of all sessions for the user
+		sessions := make([]*Session, 0, len(sessionMap))
+		for sessionID, lastSeen := range sessionMap {
+			sessions = append(sessions, &Session{
+				ID:       sessionID,
+				LastSeen: lastSeen,
+			})
+		}
+		// sort in descending order by time
+		sort.Slice(sessions, func(i, j int) bool {
+			return sessions[i].LastSeen.After(sessions[j].LastSeen)
+		})
+		// chose the first session (the most recently updated)
+		activeMap[user] = sessions[0]
+	}
+	return activeMap
 }

--- a/session/list.go
+++ b/session/list.go
@@ -1,0 +1,40 @@
+package session
+
+import "time"
+
+// Session represents known login sessions of other users. The Id
+// field is unique per session, and LastSeen is the most recent
+// time at which the session has been active.
+type Session struct {
+	ID       string
+	LastSeen time.Time
+}
+
+// List represents the known active user sessions on an arbor server.
+type List struct {
+	Active map[string][]*Session
+}
+
+// NewList creates an empty list of sessions.
+func NewList() *List {
+	return &List{make(map[string][]*Session)}
+}
+
+// Add updates the List with the given session information for the given
+// user. If the user has a session with the same ID already, the LastSeen
+// time is updated to reflect the LastSeen time in sess.
+func (l *List) Add(username string, sess Session) error {
+	return nil
+}
+
+// Remove takes the session with ID sessID out of the List for the user
+// with username.
+func (l *List) Remove(username, sessID string) error {
+	return nil
+}
+
+// ActiveSessions returns a map from usernames to the most active session
+// for each user.
+func (l *List) ActiveSessions() map[string]*Session {
+	return nil
+}

--- a/session/list_test.go
+++ b/session/list_test.go
@@ -1,0 +1,128 @@
+package session_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/arborchat/muscadine/session"
+	"github.com/onsi/gomega"
+)
+
+const (
+	username    = "username"
+	sessionName = "sessionname"
+)
+
+// TestCreateUserList ensures that CreateUserList returns a valid UserList
+func TestCreateUserList(t *testing.T) {
+	g := gomega.NewGomegaWithT(t)
+	list := session.NewList()
+	g.Expect(list).ToNot(gomega.BeNil())
+}
+
+// TestAddSession ensures that adding a valid session succeeds
+func TestAddSession(t *testing.T) {
+	g := gomega.NewGomegaWithT(t)
+	list := session.NewList()
+	err := list.Add(username, session.Session{ID: sessionName, LastSeen: time.Now()})
+	g.Expect(err).To(gomega.BeNil())
+	// adding the same session twice should not err
+	err = list.Add(username, session.Session{ID: sessionName, LastSeen: time.Now()})
+	g.Expect(err).To(gomega.BeNil())
+}
+
+// TestAddBadSession ensures that adding an invalid session succeeds
+func TestAddBadSession(t *testing.T) {
+	g := gomega.NewGomegaWithT(t)
+	list := session.NewList()
+	err := list.Add("", session.Session{sessionName, time.Now()})
+	g.Expect(err).ToNot(gomega.BeNil())
+	err = list.Add(username, session.Session{})
+	g.Expect(err).ToNot(gomega.BeNil())
+}
+
+// TestRemoveSession ensures that removing a real session succeeds
+func TestRemoveSession(t *testing.T) {
+	g := gomega.NewGomegaWithT(t)
+	list := session.NewList()
+	err := list.Add(username, session.Session{ID: sessionName, LastSeen: time.Now()})
+	if err != nil {
+		t.Skip("Adding failed", err)
+	}
+	err = list.Remove(username, sessionName)
+	g.Expect(err).To(gomega.BeNil())
+
+	// removing it again should fail
+	err = list.Remove(username, sessionName)
+	g.Expect(err).ToNot(gomega.BeNil())
+}
+
+// TestRemoveFakeSession ensures that removing a nonexistent session fails
+func TestRemoveFakeSession(t *testing.T) {
+	g := gomega.NewGomegaWithT(t)
+	list := session.NewList()
+	err := list.Remove(username, sessionName)
+	g.Expect(err).ToNot(gomega.BeNil())
+}
+
+// TestRemoveInvalidSession ensures that invalid parameters cause an error
+func TestRemoveInvalidSession(t *testing.T) {
+	g := gomega.NewGomegaWithT(t)
+	list := session.NewList()
+	err := list.Remove(username, "")
+	g.Expect(err).ToNot(gomega.BeNil())
+	err = list.Remove("", sessionName)
+	g.Expect(err).ToNot(gomega.BeNil())
+}
+
+// TestActiveSessions ensures that the ActiveSessions accessor returns a properly
+// structured map of users and their most-recently-active sessions
+func TestActiveSessions(t *testing.T) {
+	g := gomega.NewGomegaWithT(t)
+	list := session.NewList()
+	_ = list.Add(username, session.Session{sessionName, time.Now()})
+	active := list.ActiveSessions()
+	g.Expect(active).ToNot(gomega.BeNil())
+	g.Expect(len(active)).To(gomega.BeEquivalentTo(1))
+}
+
+// TestActiveMultiSessions ensures that the ActiveSessions accessor returns a properly
+// structured map of users and their most-recently-active sessions when there
+// is more than one session for the same user
+func TestActiveMultiSessions(t *testing.T) {
+	g := gomega.NewGomegaWithT(t)
+	list := session.NewList()
+	secondName := sessionName + "-second"
+	_ = list.Add(username, session.Session{sessionName, time.Now().Add(-1 * time.Second)})
+	_ = list.Add(username, session.Session{secondName, time.Now()})
+	// multiple sessions for the same user should still result in a single result
+	active := list.ActiveSessions()
+	g.Expect(active).ToNot(gomega.BeNil())
+	g.Expect(len(active)).To(gomega.BeEquivalentTo(1))
+	// the more recently-added session should come out
+	for username, session := range active {
+		g.Expect(username).To(gomega.BeEquivalentTo(username))
+		g.Expect(session.ID).To(gomega.BeEquivalentTo(secondName))
+	}
+}
+
+// TestActiveMultiUserSessions ensures that the ActiveSessions accessor returns a properly
+// structured map of users and their most-recently-active sessions when there
+// are multiple users
+func TestActiveMultiUserSessions(t *testing.T) {
+	g := gomega.NewGomegaWithT(t)
+	list := session.NewList()
+	secondUser := username + "-second"
+	_ = list.Add(username, session.Session{sessionName, time.Now()})
+	_ = list.Add(secondUser, session.Session{sessionName, time.Now()})
+	// multiple sessions for the same user should still result in a single result
+	active := list.ActiveSessions()
+	g.Expect(active).ToNot(gomega.BeNil())
+	g.Expect(len(active)).To(gomega.BeEquivalentTo(2))
+	usernames := make([]string, 0, 2)
+	for username := range active {
+		usernames = append(usernames, username)
+	}
+	g.Expect(usernames).To(gomega.ContainElement(username))
+	g.Expect(usernames).To(gomega.ContainElement(secondUser))
+}


### PR DESCRIPTION
This PR lays the groundwork for better tracking of the online status of other users. It does this by implementing a new `session` package with a `List` type designed track to which other users are online.

This work is intended to be leveraged by an Arbor 0.2 version of muscadine, but I'd like to merge this PR whenever possible. This PR does not add any features to muscadine, but enables future features. Reviewing it now will help keep future PRs that use it to a sane size.

Conceptually, a "Session" is a running client connected to a server. When an arbor client connects, it can decide on a random "session id" for that lifetime, and it can use a protocol extension to broadcast "Hey, I (username) am here on (session id) at (time)" (in a META message). Other clients then track that this user announced their presence with the given session ID at whatever time the message indicates.

When a client disconnects, it should send a "Hey, I (username) am closing session (session id)" (as a META message). This allows other clients to remove that session from their tracking.

You might be wondering what the point of session IDs is. It's to allow the same user to sign in from multiple devices simultaneously. My phone, laptop, and desktop should all randomly choose different session IDs, so that when I shut down my desktop (and announce that I'm closing that session), you can tell that I still have two open sessions on other devices. We could have implemented this as a "count how many times a user joins and how many times they leave, the difference is their number of open sessions", but that assumes that the [quit] message (or equivalent) is *always* delivered reliably. That accounting would be screwed up by client crashes, among other things. I think this is the simplest way to implement this that satisfies our current multi-client use-case.

I'd love any feedback or suggestions.