### PR TITLE
Restructure notification logic to be more configurable

### DIFF
--- a/client.go
+++ b/client.go
@@ -30,7 +30,9 @@ func TCPDial(address string) (io.ReadWriteCloser, error) {
 type NetClient struct {
 	*archive.Manager
 	Composer
+	*Notifier
 	address string
+
 	arbor.ReadWriteCloser
 	connectFunc       Connector
 	disconnectHandler func(types.Connection)
@@ -183,8 +185,8 @@ func (nc *NetClient) handleMessage(m *arbor.ProtocolMessage) {
 		if !nc.Archive.Has(m.UUID) {
 			if nc.receiveHandler != nil {
 				nc.receiveHandler(m.ChatMessage)
-				// ask notificationEngine to display the message
-				notificationEngine(nc, m.ChatMessage)
+				// ask Notifier to handle the message
+				nc.Notifier.Handle(nc, m.ChatMessage)
 			}
 			if m.Parent != "" && !nc.Archive.Has(m.Parent) {
 				nc.Query(m.Parent)

--- a/main.go
+++ b/main.go
@@ -96,6 +96,9 @@ func main() {
 		log.Println("Error creating client", err)
 		return
 	}
+	// configure notification logic to send desktop notification on all recent messages
+	notifier := &Notifier{ShouldNotify: Recent}
+	client.Notifier = notifier
 	ui, err = tui.NewTUI(client)
 	if err != nil {
 		log.Fatal("Error creating TUI", err)

--- a/notify.go
+++ b/notify.go
@@ -7,14 +7,29 @@ import (
 	"github.com/gen2brain/beeep"
 )
 
-// This method makes notifications and handles all notification logic
-func notificationEngine(cli *NetClient, msg *arbor.ChatMessage) {
+// Notifier manages sending notifications about new messages
+type Notifier struct {
+	// a function to decide whether to send notifications
+	ShouldNotify func(*NetClient, *arbor.ChatMessage) bool
+}
+
+// Handle processes a message and sends any notifications based on the
+// current notification policy.
+func (n *Notifier) Handle(cli *NetClient, msg *arbor.ChatMessage) {
+	if n.ShouldNotify(cli, msg) {
+		beeep.Notify("Muscadine", msg.Username+": "+msg.Content, "")
+	}
+}
+
+// Recent sends a notification for every incoming message within the recent
+// past that wasn't authored by the current user.
+func Recent(cli *NetClient, msg *arbor.ChatMessage) bool {
 	// is the message new?
 	if msg.Timestamp > (time.Now().Unix() - int64(5)) {
 		// do not reply to self
 		if cli.username != msg.Username {
-			toSend := msg.Username + ": " + msg.Content
-			beeep.Notify("Muscadine", toSend, "")
+			return true
 		}
 	}
+	return false
 }


### PR DESCRIPTION
This opens the door for notification policies in the future by providing alternative implementations of `Notifier.ShouldNotify`. These could easily be provided as flags (or, later, as config file options).