### PR TITLE
Create build script to track version numbers

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -211,6 +211,7 @@
     "github.com/gen2brain/beeep",
     "github.com/mattn/go-runewidth",
     "github.com/multiformats/go-multicodec/json",
+    "github.com/nu7hatch/gouuid",
     "github.com/onsi/gomega",
     "github.com/whereswaldon/gocui",
   ]

--- a/README.md
+++ b/README.md
@@ -47,10 +47,11 @@ The best way to install Muscadine is to head over to our [Releases](https://gith
 
 ## Build
 
-If you'd like to build Muscadine, make sure you have Go installed. Then run:
+If you'd like to build Muscadine, make sure you have [Go](https://golang.org/) and [dep](https://github.com/golang/dep) installed. Clone this repository, then run:
 
 ```
-go get -u github.com/arborchat/muscadine
+cd muscadine
+./build.sh
 ```
 
 ## Use

--- a/build-releases.sh
+++ b/build-releases.sh
@@ -35,7 +35,7 @@ hub release create $release_flags --message="$message" --commitish="$head_commit
 for os in darwin linux windows openbsd; do
     archive_name="$project-$os.tar.gz"
     echo "Building $project for $os"
-    env GOOS="$os" CGO_ENABLED=0 go build -o "$bin_name" &&\
+    env GOOS="$os" CGO_ENABLED=0 ./build.sh -o "$bin_name" &&\
     tar czf "$archive_name" "$bin_name" &&\
     rm "$bin_name"
     echo "Adding $archive_name to release $tag"

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,33 @@
+#!/bin/sh
+
+# find the directory containing this script
+script_dir="$(dirname "$(command -v "$0")")"
+
+# ensure that git commands are run from within this repository
+cd "$script_dir" || exit 1
+
+commit="$(git rev-parse HEAD)"
+suffix=""
+version_file="$(pwd)/version.go"
+
+# check if git is clean. If not, notify user and taint the build
+if ! git diff --exit-code > /dev/null 2>&1 ||\
+   ! git diff --cached --exit-code > /dev/null 2>&1 ; then
+    suffix="-modified"
+    echo "Warning: your current working directory contains unstaged or uncommitted changes.
+Building a \"modified\" binary
+Run 'git diff && git diff --cached' to see your unmodified changes"
+fi
+
+# write the file and format it
+echo "package main; const Version = \"$commit$suffix\"" > "$version_file"
+gofmt -s -w "$version_file"
+
+# show the user
+echo "Wrote file $version_file:"
+cat "$version_file"
+
+# ensure dependencies are clean
+dep ensure
+
+go build

--- a/build.sh
+++ b/build.sh
@@ -1,4 +1,5 @@
 #!/bin/sh
+#usage: ./build.sh <options for `go build`>
 
 # find the directory containing this script
 script_dir="$(dirname "$(command -v "$0")")"
@@ -24,10 +25,9 @@ echo "package main; const Version = \"$commit$suffix\"" > "$version_file"
 gofmt -s -w "$version_file"
 
 # show the user
-echo "Wrote file $version_file:"
-cat "$version_file"
+echo "Wrote file $version_file"
 
 # ensure dependencies are clean
 dep ensure
 
-go build
+go build "$@"

--- a/main.go
+++ b/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"flag"
 	"fmt"
+
 	"log"
 	"os"
 	"os/user"
@@ -70,11 +71,17 @@ func main() {
 		username          string
 		histfile, logfile string
 		histfileTemplate  = getDefaultHistFileTemplate()
+		version           bool
 	)
 	flag.StringVar(&username, "username", "muscadine", "Set your username on the server")
 	flag.StringVar(&histfile, "histfile", histfileTemplate, "Load/Store history in this file")
 	flag.StringVar(&logfile, "logfile", getDefaultLogFile(), "Write logs to this file")
+	flag.BoolVar(&version, "version", false, "Print version number and exit")
 	flag.Parse()
+	if version {
+		fmt.Printf("Muscadine %s\n", Version)
+		return
+	}
 	if len(flag.Args()) < 1 {
 		log.Fatal("Usage: " + os.Args[0] + " <ip>:<port>")
 	}

--- a/version.go
+++ b/version.go
@@ -1,0 +1,3 @@
+package main
+
+const Version = "go-get (unstable, use ./build.sh instead)"


### PR DESCRIPTION
~This is work-in-progress right now.~

I'm implementing @Caton101's suggestion of a build script that does the "right" thing so that our builds on our local machines are comparable, and are comparable to builds on TravisCI. ~Not done yet, but this is my progress so far. I'll update this PR as I go.~