### PR TITLE
Remove deprecated multicodec implementation from dependencies

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -50,39 +50,12 @@
   version = "v1.0.1"
 
 [[projects]]
-  digest = "1:f2ffb104978341aadea72e33f375d42c5e1954f3f6f489f2950b18a4a494cff3"
-  name = "github.com/libp2p/go-buffer-pool"
-  packages = ["."]
-  pruneopts = "UT"
-  revision = "1d28ab5fdb424e5b3523d357553082e68df9b068"
-  version = "v0.1.1"
-
-[[projects]]
-  digest = "1:c5cd39920e0b418c165c04c54717e162db866b5662c3508add7cab5a2c23dd66"
-  name = "github.com/libp2p/go-msgio"
-  packages = ["."]
-  pruneopts = "UT"
-  revision = "031a413e66129d593337a3f5948d9364e7fc6d43"
-  version = "v0.0.6"
-
-[[projects]]
   digest = "1:cdb899c199f907ac9fb50495ec71212c95cb5b0e0a8ee0800da0238036091033"
   name = "github.com/mattn/go-runewidth"
   packages = ["."]
   pruneopts = "UT"
   revision = "ce7b0b5c7b45a81508558cd1dba6bb1e4ddb51bb"
   version = "v0.0.3"
-
-[[projects]]
-  digest = "1:1d3c452788fb76aa238ccb2661533139af2d21d47ff137447adb06f82bd42e8f"
-  name = "github.com/multiformats/go-multicodec"
-  packages = [
-    ".",
-    "json",
-  ]
-  pruneopts = "UT"
-  revision = "b67bc51f663437753e2028cc4b5fea6192479956"
-  version = "v0.1.6"
 
 [[projects]]
   branch = "master"
@@ -210,7 +183,7 @@
     "github.com/bbrks/wrap",
     "github.com/gen2brain/beeep",
     "github.com/mattn/go-runewidth",
-    "github.com/multiformats/go-multicodec/json",
+    "github.com/nu7hatch/gouuid",
     "github.com/onsi/gomega",
     "github.com/whereswaldon/gocui",
   ]

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -41,10 +41,6 @@
   name = "github.com/mattn/go-runewidth"
   version = "0.0.3"
 
-[[constraint]]
-  name = "github.com/multiformats/go-multicodec"
-  version = "0.1.6"
-
 [prune]
   go-tests = true
   unused-packages = true

--- a/archive/archive.go
+++ b/archive/archive.go
@@ -1,12 +1,12 @@
 package archive
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 	"sort"
 
 	arbor "github.com/arborchat/arbor-go"
-	"github.com/multiformats/go-multicodec/json"
 )
 
 // Archive stores the chat history of conversations had over Arbor.
@@ -122,8 +122,7 @@ func (a *Archive) Persist(storage io.Writer) error {
 	if storage == nil {
 		return fmt.Errorf("Unable to persist to nil")
 	}
-	mc := mc_json.Multicodec(false)
-	encoder := mc.Encoder(storage)
+	encoder := json.NewEncoder(storage)
 	return encoder.Encode(a.chronological)
 }
 
@@ -139,8 +138,7 @@ func (a *Archive) Populate(storage io.Reader) error {
 	if storage == nil {
 		return fmt.Errorf("Unable to load from nil")
 	}
-	mc := mc_json.Multicodec(false)
-	decoder := mc.Decoder(storage)
+	decoder := json.NewDecoder(storage)
 	if len(a.chronological) < 1 {
 		return decoder.Decode(&a.chronological)
 	}

--- a/archive/archive_test.go
+++ b/archive/archive_test.go
@@ -209,6 +209,32 @@ func TestPopulatePersist(t *testing.T) {
 	}
 }
 
+// TestPopulatePersistOld ensures that an Archive can load messages from the old
+// archive format (pre multicodec-go deprecation).
+func TestPopulatePersistOld(t *testing.T) {
+	a := newOrSkip(t)
+	message := arbor.ChatMessage{
+		UUID:      "whatever",
+		Parent:    "something",
+		Content:   "a lame test",
+		Timestamp: 500000,
+		Username:  "Socrates",
+	}
+	addOrSkip(t, a, &message)
+	buf := new(bytes.Buffer)
+	n, err := buf.Write(archive.OldArchivePrefix)
+	if err != nil || n != len(archive.OldArchivePrefix) {
+		t.Skip("Unable to write prefix into buffer", err)
+	}
+	if err := a.Persist(buf); err != nil {
+		t.Error("Unable to persist messages to in-memory buffer", err)
+	}
+	a2 := newOrSkip(t)
+	if err := a2.Populate(buf); err != nil {
+		t.Error("Loading old archive format failed", err)
+	}
+}
+
 func persistOrSkip(t *testing.T, m *arbor.ChatMessage) io.Reader {
 	a := newOrSkip(t)
 	buf := new(bytes.Buffer)


### PR DESCRIPTION
**Feature/Fix explanation**

I discovered today that [this library](https://github.com/multiformats/go-multicodec/) (which we use to store the archive of your chat history) has been deprecated. Removing it from our codebase was really easy (and it's the cause of #88), so I have done so.

This created a complication, however, because that library used to write a 7-byte codec-identifying prefix at the beginning of a history file. Now that we're just deserializing the JSON directly, that prefix causes us to mis-parse (and causes history loading to fail).

To get around this problem, I've implemented a compatibility layer on the `Populate` method. If the code encounters an archive created using multicodec, it will read the seven-byte prefix and silently discard it before passing the data on to the JSON deserializer. When the client later saves its history, it will overwrite the history file with the new format (no prefix). Once we've had this in place for a while, we should no longer need the compatibility code, and will be able to remove it.

Review required: @arborchat/devs
