### PR TITLE
Open archive in read-write so we can save it

### DIFF
--- a/archive/archive_manager_test.go
+++ b/archive/archive_manager_test.go
@@ -221,3 +221,24 @@ func TestOpenFileCreate(t *testing.T) {
 	err = os.Remove(tmpPath)
 	g.Expect(err).To(gomega.BeNil())
 }
+
+// TestOpenFileWrite checks that the OpenFile function returns a writable file.
+func TestOpenFileWrite(t *testing.T) {
+	g := gomega.NewGomegaWithT(t)
+	id, err := uuid.NewV4()
+	if err != nil {
+		t.Skip(err)
+	}
+	idString := id.String()
+	tmpDir := os.TempDir()
+	tmpPath := path.Join(tmpDir, idString, idString)
+	file, err := archive.OpenFile(tmpPath)
+	g.Expect(err).To(gomega.BeNil())
+	g.Expect(file).ToNot(gomega.BeNil())
+	_, err = file.Write([]byte("test"))
+	g.Expect(err).To(gomega.BeNil())
+	err = file.Close()
+	g.Expect(err).To(gomega.BeNil())
+	err = os.Remove(tmpPath)
+	g.Expect(err).To(gomega.BeNil())
+}

--- a/archive/manager.go
+++ b/archive/manager.go
@@ -20,10 +20,11 @@ type Opener func(string) (io.ReadWriteCloser, error)
 
 // OpenFile is an Opener that reads a file from disk.
 func OpenFile(histPath string) (io.ReadWriteCloser, error) {
-	file, err := os.Open(histPath)
+	const perms = 0700
+	file, err := os.OpenFile(histPath, os.O_RDWR, perms)
 	if err != nil {
 		if os.IsNotExist(err) {
-			if err := os.MkdirAll(path.Dir(histPath), 0700); err != nil {
+			if err := os.MkdirAll(path.Dir(histPath), perms); err != nil {
 				return nil, err
 			}
 			return os.Create(histPath)


### PR DESCRIPTION
Our history files haven't been saving properly for a while now. This is because (in my idiocy), the archive refactor was opening all archive files readonly. I've implemented read/write and a test to prevent this mistake in the future.

---

Review required: @arborchat/devs
