### PR TITLE
Highlight descendant messages

### DIFF
--- a/tui/history_state.go
+++ b/tui/history_state.go
@@ -31,13 +31,17 @@ const (
 	defaultHistoryCapacity = 1000
 	defaultHistoryLength   = 0
 	red                    = "\x1b[0;31m"
+	green                  = "\x1b[0;32m"
 	yellow                 = "\x1b[0;33m"
 	// CurrentColor is the ANSI escape sequence for the color that is used to highlight
 	// the currently-selected message
 	CurrentColor = red
-	// AncestorColor is the ANSI escape sequence for the color that is use to highlight
+	// AncestorColor is the ANSI escape sequence for the color that is used to highlight
 	// the ancestors of the currently-selected message
 	AncestorColor = yellow
+	// DescendentColor is the ANSI escape sequence for the color that is used to highlight
+	// the descendents of the currently-selected message
+	DescendentColor = green
 	// ClearColor is the ANSI escape sequence to return to the default color
 	ClearColor = "\x1b[0;0m"
 )
@@ -136,6 +140,21 @@ func (h *HistoryState) currentAncestors() []string {
 	return ancestors
 }
 
+// currentDescendents returns all known descendents of the HistoryState's currently-selected
+// message.
+func (h *HistoryState) currentDescendents() []string {
+	descendents := make([]string, 0)
+	if len(h.History) < 2 {
+		return descendents
+	}
+	currentID := h.History[h.currentIndex].UUID
+	descendents = append(descendents, h.Archive.ChildrenOf(currentID)...)
+	for i := 0; i < len(descendents); i++ {
+		descendents = append(descendents, h.Archive.ChildrenOf(descendents[i])...)
+	}
+	return descendents
+}
+
 // Render writes the correct contents of the history to the provided
 // writer. Each time it is invoked, it will render the entire history, so the
 // writer should be empty when it is invoked.
@@ -145,6 +164,7 @@ func (h *HistoryState) Render(target io.Writer) error {
 	renderableHist := h.History
 	renderedHistLines := make([][]byte, 0, h.renderHeight) // ensure starting len is zero
 	ancestors := h.currentAncestors()
+	descendents := h.currentDescendents()
 	var (
 		colorPre, colorPost string
 	)
@@ -156,12 +176,20 @@ func (h *HistoryState) Render(target io.Writer) error {
 		} else {
 			colorPre = ""
 			colorPost = ""
-		colorize:
+		ancestorColorize:
 			for _, id := range ancestors {
 				if id == message.UUID {
 					colorPre = AncestorColor
 					colorPost = ClearColor
-					break colorize
+					break ancestorColorize
+				}
+			}
+		descendentColorize:
+			for _, id := range descendents {
+				if id == message.UUID {
+					colorPre = DescendentColor
+					colorPost = ClearColor
+					break descendentColorize
 				}
 			}
 		}

--- a/tui/history_state.go
+++ b/tui/history_state.go
@@ -39,9 +39,9 @@ const (
 	// AncestorColor is the ANSI escape sequence for the color that is used to highlight
 	// the ancestors of the currently-selected message
 	AncestorColor = yellow
-	// DescendentColor is the ANSI escape sequence for the color that is used to highlight
-	// the descendents of the currently-selected message
-	DescendentColor = green
+	// DescendantColor is the ANSI escape sequence for the color that is used to highlight
+	// the descendants of the currently-selected message
+	DescendantColor = green
 	// ClearColor is the ANSI escape sequence to return to the default color
 	ClearColor = "\x1b[0;0m"
 )
@@ -140,19 +140,19 @@ func (h *HistoryState) currentAncestors() []string {
 	return ancestors
 }
 
-// currentDescendents returns all known descendents of the HistoryState's currently-selected
+// currentDescendants returns all known descendants of the HistoryState's currently-selected
 // message.
-func (h *HistoryState) currentDescendents() []string {
-	descendents := make([]string, 0)
+func (h *HistoryState) currentDescendants() []string {
+	descendants := make([]string, 0)
 	if len(h.History) < 2 {
-		return descendents
+		return descendants
 	}
 	currentID := h.History[h.currentIndex].UUID
-	descendents = append(descendents, h.Archive.ChildrenOf(currentID)...)
-	for i := 0; i < len(descendents); i++ {
-		descendents = append(descendents, h.Archive.ChildrenOf(descendents[i])...)
+	descendants = append(descendants, h.Archive.ChildrenOf(currentID)...)
+	for i := 0; i < len(descendants); i++ {
+		descendants = append(descendants, h.Archive.ChildrenOf(descendants[i])...)
 	}
-	return descendents
+	return descendants
 }
 
 // Render writes the correct contents of the history to the provided
@@ -164,7 +164,7 @@ func (h *HistoryState) Render(target io.Writer) error {
 	renderableHist := h.History
 	renderedHistLines := make([][]byte, 0, h.renderHeight) // ensure starting len is zero
 	ancestors := h.currentAncestors()
-	descendents := h.currentDescendents()
+	descendants := h.currentDescendants()
 	var (
 		colorPre, colorPost string
 	)
@@ -184,12 +184,12 @@ func (h *HistoryState) Render(target io.Writer) error {
 					break ancestorColorize
 				}
 			}
-		descendentColorize:
-			for _, id := range descendents {
+		descendantColorize:
+			for _, id := range descendants {
 				if id == message.UUID {
-					colorPre = DescendentColor
+					colorPre = DescendantColor
 					colorPost = ClearColor
-					break descendentColorize
+					break descendantColorize
 				}
 			}
 		}

--- a/types/interfaces.go
+++ b/types/interfaces.go
@@ -49,6 +49,7 @@ type Archive interface {
 	Has(id string) bool
 	Get(id string) *arbor.ChatMessage
 	Root() (string, error)
+	ChildrenOf(string) []string
 	Add(message *arbor.ChatMessage) error
 	Persist(storage io.Writer) error
 	Populate(storage io.Reader) error


### PR DESCRIPTION
Implements/Fixes #5.

Erase all that do not apply:
- This PR modified the visible UI

**Feature/Fix explanation**

At long last, you can see the descendants of the visible message. This is one of the oldest feature requests, and I decided that it was time to just do it already. It was (happily) easier than I expected.

---

Review required: @arborchat/devs
