### PR TITLE
Clean repo

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: go
 dist: xenial
 install:
     - curl -O -L https://github.com/golang/dep/releases/download/v0.5.0/dep-linux-amd64 && chmod +x dep-linux-amd64 && mv dep-linux-amd64 "$GOPATH/bin"
-    - dep ensure
+    - "$GOPATH/bin/dep" ensure
 script:
     - go test -v -cover ./...
     - for os in linux darwin windows openbsd; do echo "building for $os" && env GOOS="$os" go build -o /dev/null; done

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: go
 dist: xenial
 install:
-    - curl -O -L https://github.com/golang/dep/releases/download/v0.5.0/dep-linux-amd64 && chmod +x dep-linux-amd64 && mv dep-linux-amd64 "$GOPATH/bin"
+    - curl -O -L https://github.com/golang/dep/releases/download/v0.5.0/dep-linux-amd64 && chmod +x dep-linux-amd64 && mv dep-linux-amd64 "$GOPATH/bin/dep"
     - "$GOPATH/bin/dep" ensure
 script:
     - go test -v -cover ./...

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: go
 dist: xenial
 install:
-    - curl https://raw.githubusercontent.com/golang/dep/master/install.sh | sh
+    - curl -O -L https://github.com/golang/dep/releases/download/v0.5.0/dep-linux-amd64 && chmod +x dep-linux-amd64 && mv dep-linux-amd64 "$GOPATH/bin"
     - dep ensure
 script:
     - go test -v -cover ./...

--- a/build-releases.sh
+++ b/build-releases.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 
+# use bash strict mode
 set -euo pipefail
 
 # only build on master

--- a/build.sh
+++ b/build.sh
@@ -12,8 +12,8 @@ suffix=""
 version_file="$(pwd)/version.go"
 
 # check if git is clean. If not, notify user and taint the build
-if ! git diff --exit-code > /dev/null 2>&1 ||\
-   ! git diff --cached --exit-code > /dev/null 2>&1 ; then
+if ! git diff --stat --exit-code ||\
+   ! git diff --stat --cached --exit-code ; then
     suffix="-modified"
     echo "Warning: your current working directory contains unstaged or uncommitted changes.
 Building a \"modified\" binary

--- a/build.sh
+++ b/build.sh
@@ -1,5 +1,7 @@
-#!/bin/sh
+#!/bin/bash
 #usage: ./build.sh <options for `go build`>
+
+set -euo pipefail
 
 # find the directory containing this script
 script_dir="$(dirname "$(command -v "$0")")"

--- a/build.sh
+++ b/build.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 #usage: ./build.sh <options for `go build`>
 
+# use bash strict mode
 set -euo pipefail
 
 # find the directory containing this script

--- a/build.sh
+++ b/build.sh
@@ -30,4 +30,8 @@ echo "Wrote file $version_file"
 # ensure dependencies are clean
 dep ensure
 
+# actually perform the build
 go build "$@"
+
+# reset the version.go file so that the git repo doesn't appear modified
+git checkout HEAD -- "$version_file"


### PR DESCRIPTION
**Feature/Fix explanation**

The goal of this PR is to ensure that builds on Travis are clean (do not have the `-modified` suffix in their version. In an attempt to do this, this PR resets the version file after each build and locks us to a specific stable version of dep (to prevent rewriting Gopkg.lock).

---

Review required: @arborchat/devs
