### PR TITLE
Add list of online users to TUI

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ The keybindings are:
     - home/g - jump to top of history
     - end/G - jump to bottom of history
     - q - query the server for any missing chat history (only necessary if top status bar indicates)
+    - w - toggle the list of active users (covers part of history)
 - Compose Mode:
     - enter - send your message (unless in paste mode)
     - ctrl+p - toggle "paste mode", in which the enter key will *not* send the message, but instead type a newline

--- a/session/list.go
+++ b/session/list.go
@@ -67,7 +67,10 @@ func (l *List) Remove(username, sessID string) error {
 		if exists {
 			// delete the session if we found it
 			delete(userSessions, sessID)
-			// TODO: delete the whole map for the user if this was their only session
+			// delete the whole map for the user if this was their only session
+			if len(l.Active[username]) == 0 {
+				delete(l.Active, username)
+			}
 			return nil
 		}
 		// we were asked to delete a nonexistent session

--- a/session/list.go
+++ b/session/list.go
@@ -79,8 +79,8 @@ func (l *List) Remove(username, sessID string) error {
 
 // ActiveSessions returns a map from usernames to the most active session
 // for each user.
-func (l *List) ActiveSessions() map[string]*Session {
-	activeMap := make(map[string]*Session)
+func (l *List) ActiveSessions() map[string]time.Time {
+	activeMap := make(map[string]time.Time)
 	for user, sessionMap := range l.Active {
 		// make a list of all sessions for the user
 		sessions := make([]*Session, 0, len(sessionMap))
@@ -95,7 +95,7 @@ func (l *List) ActiveSessions() map[string]*Session {
 			return sessions[i].LastSeen.After(sessions[j].LastSeen)
 		})
 		// chose the first session (the most recently updated)
-		activeMap[user] = sessions[0]
+		activeMap[user] = sessions[0].LastSeen
 	}
 	return activeMap
 }

--- a/session/list_test.go
+++ b/session/list_test.go
@@ -128,3 +128,16 @@ func TestActiveMultiUserSessions(t *testing.T) {
 	g.Expect(usernames).To(gomega.ContainElement(username))
 	g.Expect(usernames).To(gomega.ContainElement(secondUser))
 }
+
+// TestActiveSessionsEmpty ensures that ActiveSessions behaves correctly
+// when there are no known sessions
+func TestActiveSessionsEmpty(t *testing.T) {
+	g := gomega.NewGomegaWithT(t)
+	list := session.NewList()
+	sessions := list.ActiveSessions()
+	g.Expect(sessions).To(gomega.BeEmpty())
+	list.Track("foo", session.Session{"bar", time.Now()})
+	list.Remove("foo", "bar")
+	sessions = list.ActiveSessions()
+	g.Expect(sessions).To(gomega.BeEmpty())
+}

--- a/session/list_test.go
+++ b/session/list_test.go
@@ -93,16 +93,18 @@ func TestActiveMultiSessions(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
 	list := session.NewList()
 	secondName := sessionName + "-second"
-	_ = list.Track(username, session.Session{sessionName, time.Now().Add(-1 * time.Second)})
-	_ = list.Track(username, session.Session{secondName, time.Now()})
+	firstSession := session.Session{sessionName, time.Now().Add(-1 * time.Second)}
+	secondSession := session.Session{secondName, time.Now()}
+	_ = list.Track(username, firstSession)
+	_ = list.Track(username, secondSession)
 	// multiple sessions for the same user should still result in a single result
 	active := list.ActiveSessions()
 	g.Expect(active).ToNot(gomega.BeNil())
 	g.Expect(len(active)).To(gomega.BeEquivalentTo(1))
 	// the more recently-added session should come out
-	for username, session := range active {
+	for username, lastSeen := range active {
 		g.Expect(username).To(gomega.BeEquivalentTo(username))
-		g.Expect(session.ID).To(gomega.BeEquivalentTo(secondName))
+		g.Expect(lastSeen).To(gomega.BeEquivalentTo(secondSession.LastSeen))
 	}
 }
 

--- a/tui/keybindings.go
+++ b/tui/keybindings.go
@@ -32,6 +32,7 @@ func (t *TUI) Keybindings() []Binding {
 		{historyView, gocui.KeyEnd, gocui.ModNone, t.scrollBottom, "scrollBottom"},
 		{historyView, 'G', gocui.ModNone, t.scrollBottom, "scrollBottom"},
 		{historyView, 'q', gocui.ModNone, t.queryNeeded, "queryNeeded"},
+		{historyView, 'w', gocui.ModNone, t.toggleUserList, "toggleUserList"},
 		{editView, gocui.KeyTab, gocui.ModNone, t.Editor.ActionInsertTab, "InsertTab"},
 		{editView, gocui.KeyEnter, gocui.ModNone, t.handleEnter, "handleEnter"},
 		{editView, gocui.KeyEsc, gocui.ModNone, t.cancelReply, "cancelReply"},

--- a/tui/tui.go
+++ b/tui/tui.go
@@ -384,7 +384,8 @@ func (t *TUI) layout(gui *gocui.Gui) error {
 	sessions := t.Client.ActiveSessions()
 	userText := ""
 	for user, lastSeen := range sessions {
-		userText += user + " seen " + time.Since(lastSeen).String() + " ago"
+		since := time.Since(lastSeen)
+		userText += fmt.Sprintf("%s seen %02dm%02ds ago\n", user, int(since.Minutes()), int(since.Seconds()))
 	}
 	userList.Clear()
 	_, err = userList.Write([]byte(userText))

--- a/tui/tui.go
+++ b/tui/tui.go
@@ -80,6 +80,7 @@ func (t *TUI) manageConnection(c types.Connection) {
 			log.Println("Connected to server")
 			go func() {
 				t.Client.AnnounceHere(t.SessionID())
+				t.Client.AskWho()
 			}()
 			break
 		}

--- a/types/interfaces.go
+++ b/types/interfaces.go
@@ -36,6 +36,7 @@ type SessionList interface {
 type Composer interface {
 	Reply(string, string) error
 	Query(string)
+	AskWho()
 	AnnounceHere(string)
 	AnnounceLeaving(string)
 }

--- a/types/interfaces.go
+++ b/types/interfaces.go
@@ -7,6 +7,7 @@ package types
 
 import (
 	"io"
+	"time"
 
 	arbor "github.com/arborchat/arbor-go"
 )
@@ -23,6 +24,11 @@ type Client interface {
 	Composer
 	Archive
 	Connection
+}
+
+// SessionList tracks the sessions of other users.
+type SessionList interface {
+	ActiveSessions() map[string]time.Time
 }
 
 // Composer writes and sends protocol messages

--- a/types/interfaces.go
+++ b/types/interfaces.go
@@ -24,6 +24,7 @@ type Client interface {
 	Composer
 	Archive
 	Connection
+	SessionList
 }
 
 // SessionList tracks the sessions of other users.


### PR DESCRIPTION
Erase all that do not apply:
- This PR modified keybindings (either changing defaults or adding new actions)
- This PR modified the visible UI

**Feature/Fix explanation**

The client has been tracking the online status of other users for a while now, and this PR finally makes it visible. Users can press `w` to toggle an overlay showing all known online users and how long it has been since each user announced that they were present (to detect stale sessions). This view updates the timestamps every second.
![image](https://user-images.githubusercontent.com/3922125/52167574-156ac680-26eb-11e9-9b54-075bc3d0fd98.png)

---

Review required: @arborchat/devs
